### PR TITLE
Shadow-Fix

### DIFF
--- a/Editor/ConsoleWindow.h
+++ b/Editor/ConsoleWindow.h
@@ -80,6 +80,9 @@ namespace ToolKit
     const String g_selectEffectingLights("SelectAllEffectingLights");
     void SelectAllEffectingLights(TagArgArray tagArgs);
 
+    const String g_checkSceneHealth("CheckSceneHealth");
+    void CheckSceneHealth(TagArgArray tagArgs);
+
     // Command errors
     const String g_noValidEntity("No valid entity");
 

--- a/ToolKit/GeometryTypes.h
+++ b/ToolKit/GeometryTypes.h
@@ -1,72 +1,134 @@
 #pragma once
 
+/**
+ * @file
+ * This file contains declarations for various geometric shapes and related
+ * utilities.
+ */
+
 #include "Types.h"
 
 namespace ToolKit
 {
 
+  /**
+   * A templated struct for a rectangle with X, Y, Width and Height.
+   * @tparam T The type of the rectangle's components.
+   */
   template <class T>
   struct Rect
   {
-    T X;
-    T Y;
-    T Width;
-    T Height;
+    T X;      //!< The X-coordinate of the rectangle.
+    T Y;      //!< The Y-coordinate of the rectangle.
+    T Width;  //!< The width of the rectangle.
+    T Height; //!< The height of the rectangle.
   };
 
+  /**
+   * A typedef for an integer-based rectangle.
+   */
   typedef Rect<int> IRectangle;
+
+  /**
+   *  A typedef for a float-based rectangle.
+   */
   typedef Rect<float> FRectangle;
 
+  /**
+   *  A struct representing a bounding box in 3D space.
+   */
   struct BoundingBox
   {
-    Vec3 min = Vec3(TK_FLT_MAX);
-    Vec3 max = Vec3(-TK_FLT_MAX);
+    Vec3 min = Vec3(TK_FLT_MAX);  //!< The minimum point of the bounding box.
+    Vec3 max = Vec3(-TK_FLT_MAX); //!< The maximum point of the bounding box.
 
-    Vec3 GetCenter() { return min + (max - min) * 0.5f; }
+    /**
+     * Check if the bounding box is valid.
+     * @return True if the bounding box is valid, false otherwise.
+     */
+    bool IsValid() const { return !glm::isinf(Volume()); }
 
+    /**
+     * Get the center point of the bounding box.
+     * @return The center point of the bounding box.
+     */
+    Vec3 GetCenter() const { return min + (max - min) * 0.5f; }
+
+    /**
+     * Update the boundary of the bounding box with a new point.
+     * @param v The new point to include in the bounding box.
+     */
     void UpdateBoundary(const Vec3& v)
     {
       max = glm::max(max, v);
       min = glm::min(min, v);
     }
 
+    /**
+     * Update the boundary of the bounding box with another bounding box.
+     * @param bb The bounding box to include in the bounding box.
+     */
     void UpdateBoundary(const BoundingBox& bb)
     {
       UpdateBoundary(bb.max);
       UpdateBoundary(bb.min);
     }
 
-    float Volume()
+    /**
+     * Get the volume of the bounding box.
+     * @return The volume of the bounding box.
+     */
+    float Volume() const
     {
       return glm::abs((max.x - min.x) * (max.y - min.y) * (max.z - min.z));
     }
 
+    /**
+     * Get the width of the bounding box.
+     * @return The width of the bounding box.
+     */
     float GetWidth() const { return max.x - min.x; }
 
+    /**
+     * Get the height of the bounding box.
+     * @return The height of the bounding box.
+     */
     float GetHeight() const { return max.y - min.y; }
   };
 
+  /**
+   * A struct representing a ray in 3D space.
+   */
   struct Ray
   {
-    Vec3 position;
-    Vec3 direction;
+    Vec3 position;  //!< The position of the ray.
+    Vec3 direction; //!< The direction of the ray.
   };
 
+  /**
+   * A struct representing a plane equation in 3D space.
+   */
   struct PlaneEquation
   {
-    Vec3 normal;
-    float d;
+    Vec3 normal; //!< The normal vector of the plane.
+    float d; //!< The distance from the origin to the plane along the normal.
   };
 
+  /**
+   * A struct representing a frustum in 3D space.
+   */
   struct Frustum
   {
     PlaneEquation planes[6]; // Left - Right - Top - Bottom - Near - Far
   };
 
+  /**
+   * A struct representing a bounding sphere in 3D space.
+   */
   struct BoundingSphere
   {
-    Vec3 pos;
-    float radius;
+    Vec3 pos;     ///< The position of the center of the sphere.
+    float radius; ///< The radius of the sphere.
   };
 
 } // namespace ToolKit

--- a/ToolKit/Logger.cpp
+++ b/ToolKit/Logger.cpp
@@ -27,32 +27,40 @@ namespace ToolKit
     m_platfromConsoleFn = fn;
   }
 
-  void OutputUtil(ConsoleOutputFn logFn, LogType logType, const char* msg, ...)
+  void OutputUtil(ConsoleOutputFn logFn,
+                  LogType logType,
+                  const char* msg,
+                  va_list args)
   {
     if (logFn == nullptr)
     {
       return;
     }
 
-    va_list args;
-    va_start(args, msg);
-
     static char buff[2048];
     vsprintf(buff, msg, args);
 
     logFn(logType, String(buff));
-
-    va_end(args);
   }
 
   void Logger::WriteConsole(LogType logType, const char* msg, ...)
   {
-    OutputUtil(m_writeConsoleFn, logType, msg);
+    va_list args;
+    va_start(args, msg);
+
+    OutputUtil(m_writeConsoleFn, logType, msg, args);
+
+    va_end(args);
   }
 
   void Logger::WritePlatformConsole(LogType logType, const char* msg, ...)
   {
-    OutputUtil(m_platfromConsoleFn, logType, msg);
+    va_list args;
+    va_start(args, msg);
+
+    OutputUtil(m_platfromConsoleFn, logType, msg, args);
+
+    va_end(args);
   }
 
 } // namespace ToolKit

--- a/ToolKit/Pass.cpp
+++ b/ToolKit/Pass.cpp
@@ -108,7 +108,17 @@ namespace ToolKit
         RenderJob& rj     = newJobs[i];
         rj.Entity         = ntt;
         rj.WorldTransform = transform;
-        rj.BoundingBox    = allMeshes[i]->m_aabb;
+
+        if (AABBOverrideComponentPtr bbOverride =
+                ntt->GetComponent<AABBOverrideComponent>())
+        {
+          rj.BoundingBox = std::move(bbOverride->GetAABB());
+        }
+        else 
+        {
+          rj.BoundingBox = allMeshes[i]->m_aabb;
+        }
+
         TransformAABB(rj.BoundingBox, transform);
 
         rj.ShadowCaster = mc->GetCastShadowVal();

--- a/ToolKit/Pass.cpp
+++ b/ToolKit/Pass.cpp
@@ -114,7 +114,7 @@ namespace ToolKit
         {
           rj.BoundingBox = std::move(bbOverride->GetAABB());
         }
-        else 
+        else
         {
           rj.BoundingBox = allMeshes[i]->m_aabb;
         }
@@ -369,7 +369,7 @@ namespace ToolKit
       BoundingBox bestBox;
       for (const EnvironmentComponentPtr& volume : environments)
       {
-        if (volume->GetIlluminateVal() == false) 
+        if (volume->GetIlluminateVal() == false)
         {
           continue;
         }
@@ -387,6 +387,44 @@ namespace ToolKit
         }
       }
     }
+  }
+
+  void RenderJobProcessor::CalculateStdev(const RenderJobArray& rjVec,
+                                          float& stdev,
+                                          Vec3& mean)
+  {
+    int n = (int) rjVec.size();
+
+    // Calculate mean position
+    Vec3 sum(0.0f);
+    for (int i = 0; i < n; i++)
+    {
+      Vec3 pos = rjVec[i].WorldTransform[3].xyz;
+      sum      += pos;
+    }
+    mean      = sum / (float) n;
+
+    // Calculate standard deviation of position
+    float ssd = 0.0f;
+    for (int i = 0; i < n; i++)
+    {
+      Vec3 pos  = rjVec[i].WorldTransform[3].xyz;
+      Vec3 diff = pos - mean;
+      ssd       += glm::dot(diff, diff);
+    }
+    stdev = std::sqrt(ssd / (float) n);
+  }
+
+  bool RenderJobProcessor::IsOutlier(const RenderJob& rj,
+                                     float sigma,
+                                     const float stdev,
+                                     const Vec3& mean)
+  {
+    Vec3 pos   = rj.WorldTransform[3].xyz;
+    Vec3 diff  = pos - mean;
+    float dist = glm::length(diff) / stdev;
+
+    return (dist > sigma);
   }
 
 } // namespace ToolKit

--- a/ToolKit/Pass.h
+++ b/ToolKit/Pass.h
@@ -89,6 +89,27 @@ namespace ToolKit
     static void AssignEnvironment(
         RenderJobArray& jobArray,
         const EnvironmentComponentPtrArray& environments);
+
+    /**
+     * Calculates the standard deviation and mean of the given RenderJobArray
+     * based on world position of the RenderJobs.
+     * @param rjVec is array containing jobs.
+     * @param stdev is the output of calculated standard deviation.
+     * @param mean is the calculated mean position.
+     */
+    static void CalculateStdev(const RenderJobArray& rjVec,
+                               float& stdev,
+                               Vec3& mean);
+
+    /**
+     * Decides if the given RenderJob is an outlier based on its world position.
+     * @param rj is the RenderJob to decide if its outlier.
+     * @param sigma is the threshold sigma to accept as outlier or not.
+     */
+    static bool IsOutlier(const RenderJob& rj,
+                          float sigma,
+                          const float stdev,
+                          const Vec3& mean);
   };
 
   /*

--- a/ToolKit/Scene.h
+++ b/ToolKit/Scene.h
@@ -1,5 +1,9 @@
 #pragma once
 
+/**
+ * @file Scene.h Header file for the Scene class.
+ */
+
 #include "Light.h"
 #include "MathUtil.h"
 #include "Resource.h"
@@ -12,55 +16,213 @@
 
 namespace ToolKit
 {
+
+  /**
+   * The Scene class represents a collection of entities in a 3D environment. It
+   * provides functionality for loading and saving scenes, updating and querying
+   * entities, and serializing/deserializing to/from XML.
+   */
   class TK_API Scene : public Resource
   {
    public:
+    /**
+     * A helper struct that holds the result of a ray-picking operation in the
+     * scene.
+     */
     struct PickData
     {
+      /**
+       * The position in world space where the ray intersects with the object.
+       */
       Vec3 pickPos;
+
+      /**
+       * A pointer to the Entity object that was picked.
+       */
       Entity* entity = nullptr;
     };
 
    public:
     TKResourceType(Scene)
 
+    /**
+     * The constructor for the Scene class.
+     */
     Scene();
+
+    /**
+     * The constructor for the Scene class that loads a scene from a file.
+     *
+     * @param file The file path of the scene to load.
+     */
     explicit Scene(String file);
+
+    /**
+     * The destructor for the Scene class.
+     */
     virtual ~Scene();
 
+    /**
+     * Loads the scene from its file.
+     */
     void Load() override;
+
+    /**
+     * Saves the scene to its file.
+     *
+     * @param onlyIfDirty If true, the scene will only be saved if it has been
+     * modified since the last save.
+     */
     void Save(bool onlyIfDirty) override;
+
+    /**
+     * Initializes the scene.
+     *
+     * @param flushClientSideArray It will pass down to resource components of
+     * the entity for initialization.
+     */
     void Init(bool flushClientSideArray = false) override;
+
+    /**
+     * Uninitializes the scene.
+     */
     void UnInit() override;
+
+    /**
+     * Updates the scene by the specified amount of time.
+     *
+     * @param deltaTime The time elapsed since the last update.
+     */
     virtual void Update(float deltaTime);
-    // Merges entities from the other scene and wipeouts the other scene.
+
+    /**
+     * Merges the entities from another scene into this scene and clears the
+     * other scene.
+     *
+     * @param other A pointer to the other scene to merge.
+     */
     virtual void Merge(ScenePtr other);
 
     // Scene queries.
+
+    /**
+     * Performs a ray-picking operation on the scene to find the first object
+     * that the ray intersects.
+     *
+     * @param ray The ray to use for picking.
+     * @param ignoreList A list of entity IDs to ignore during the picking
+     * operation.
+     * @param extraList A list of extra entity pointers to include in the
+     * picking operation.
+     *
+     * @return A PickData struct containing the result of the picking operation.
+     */
     virtual PickData PickObject(
         Ray ray,
         const EntityIdArray& ignoreList    = EntityIdArray(),
         const EntityRawPtrArray& extraList = EntityRawPtrArray());
 
-    virtual void PickObject(
-        const Frustum& frustum,
-        std::vector<PickData>& pickedObjects,
-        const EntityIdArray& ignoreList    = EntityIdArray(),
-        const EntityRawPtrArray& extraList = EntityRawPtrArray(),
-        bool pickPartiallyInside           = true);
+    /**
+     * Performs a frustum culling operation on the scene to find all objects
+     * that are partially or fully contained within the frustum.
+     *
+     * @param frustum The frustum to use for culling.
+     * @param pickedObjects An output vector to store the results of the culling
+     * operation.
+     * @param ignoreList A list of entity IDs to ignore during the culling
+     * operation.
+     * @param extraList A list of extra entity pointers to include in the
+     * culling operation.
+     * @param pickPartiallyInside If true, objects that are partially contained
+     * within the frustum will also be included.
+     */
+    virtual void PickObject(const Frustum& frustum,
+                            std::vector<PickData>& pickedObjects,
+                            const EntityIdArray& ignoreList    = {},
+                            const EntityRawPtrArray& extraList = {},
+                            bool pickPartiallyInside           = true);
 
     // Entity operations.
+
+    /**
+     * Gets the entity with the given ID from the scene.
+     * @param id The ID of the entity to get.
+     * @returns The entity with the given ID, or nullptr if no entity with that
+     * ID exists in the scene.
+     */
     Entity* GetEntity(ULongID id) const;
+
+    /**
+     * Adds an entity to the scene.
+     * @param entity The entity to add.
+     */
     virtual void AddEntity(Entity* entity);
     EntityRawPtrArray& AccessEntityArray(); //!< Mutable Entity array access.
+
+    /**
+     * Gets all the entities in the scene.
+     * @returns An array containing pointers to all the entities in the scene.
+     */
     const EntityRawPtrArray& GetEntities() const;
+
+    /**
+     * Gets an array of all the lights in the scene.
+     * @returns An array containing pointers to all the lights in the scene.
+     */
     LightRawPtrArray GetLights() const;
+
+    /**
+     * Gets the first entity in the scene with the given name.
+     * @param name The name of the entity to get.
+     * @returns The first entity in the scene with the given name, or nullptr if
+     * no entity with that name exists in the scene.
+     */
     Entity* GetFirstEntityByName(const String& name);
+
+    /**
+     * Gets an array of all the entities in the scene with the given tag.
+     * @param tag The tag to search for.
+     * @returns An array containing pointers to all the entities in the scene
+     * with the given tag.
+     */
     EntityRawPtrArray GetByTag(const String& tag);
+
+    /**
+     * Gets the first entity in the scene with the given tag.
+     * @param tag The tag to search for.
+     * @returns The first entity in the scene with the given tag, or nullptr if
+     * no entity with that tag exists in the scene.
+     */
     Entity* GetFirstByTag(const String& tag);
+
+    /**
+     * Filters the entities in the scene using the given filter function.
+     * @param filter A function that takes an Entity pointer as its argument and
+     * returns a boolean value indicating whether to include the entity in the
+     * filtered result.
+     * @returns An array containing pointers to all the entities in the scene
+     * that passed the filter function.
+     */
     EntityRawPtrArray Filter(std::function<bool(Entity*)> filter);
+
+    /**
+     * Gets the sky object associated with the scene.
+     * @returns A pointer to the SkyBase object associated with the scene, or
+     * nullptr if no sky object is associated with the scene.
+     */
     SkyBase* GetSky();
+
+    /**
+     * Links a prefab to the scene.
+     * @param fullPath The full path to the prefab file.
+     */
     void LinkPrefab(const String& fullPath);
+
+    /**
+     * Returns an array of pointers to all environment volume components in the
+     * scene.
+     * @returns The array of pointers to environment volume components.
+     */
     EnvironmentComponentPtrArray GetEnvironmentVolumes();
 
     /**
@@ -70,47 +232,148 @@ namespace ToolKit
      * @returns The removed entity.
      */
     virtual Entity* RemoveEntity(ULongID id, bool deep = true);
+
+    /**
+     * Removes an array of entities from the scene.
+     * @param entities An array of pointers to the entities to be removed.
+     */
     virtual void RemoveEntity(const EntityRawPtrArray& entities);
+
+    /**
+     * Removes all entities from the scene.
+     */
     virtual void RemoveAllEntities();
+
+    /**
+     * Destroys the scene and removes all of its resources.
+     * @param removeResources Whether to remove all associated resources or not.
+     */
     virtual void Destroy(bool removeResources);
+
+    /**
+     * Saves a prefab for an entity in the scene.
+     * @param entity The entity to create the prefab from.
+     */
     virtual void SavePrefab(Entity* entity);
+
+    /**
+     * Removes all entities from the scene.
+     */
     virtual void ClearEntities();
 
     // Serialization.
+
+    /**
+     * Serializes the scene to an XML document.
+     * @param doc The XML document to serialize to.
+     * @param parent The parent XML node to serialize under.
+     */
     void Serialize(XmlDocument* doc, XmlNode* parent) const override;
+
+    /**
+     * Deserializes the scene from an XML document.
+     * @param doc The XML document to deserialize from.
+     * @param parent The parent XML node to deserialize from.
+     */
     void DeSerialize(XmlDocument* doc, XmlNode* parent) override;
-    // Used to avoid Id collision during scene merges.
+
+    /**
+     * Returns the biggest number generated during the current runtime. This
+     * function is used to avoid ID collision during scene merges.
+     *
+     * @return The biggest entity ID generated during the current runtime.
+     */
     ULongID GetBiggestEntityId();
 
    private:
+    /**
+     * Removes all children of the given entity.
+     * @param removed The entity whose children will be removed.
+     */
     void RemoveChildren(Entity* removed);
 
    protected:
+    /**
+     * Copies the scene to another resource.
+     * @param other The resource to copy to.
+     */
     void CopyTo(Resource* other) override;
-    // Normalize entity IDs while serializing
+
+    /**
+     * Normalize the ID of an entity while serializing the scene.
+     * @param doc The XML document being serialized.
+     * @param parent The parent node of the entity being serialized.
+     * @param indx The index of the entity in the entity list.
+     */
     void NormalizeEntityID(XmlDocument* doc, XmlNode* prent, size_t indx) const;
 
    protected:
-    EntityRawPtrArray m_entities;
-    String m_version;
-    bool m_isPrefab;
+    EntityRawPtrArray m_entities; //!< The entities in the scene.
+    String m_version;             //!< The version of the scene file.
+    bool m_isPrefab;              //!< Whether or not the scene is a prefab.
   };
 
+  /**
+   * A class for managing game scenes as resources.
+   */
   class TK_API SceneManager : public ResourceManager
   {
    public:
+    /**
+     * Constructor.
+     */
     SceneManager();
+
+    /**
+     * Destructor.
+     */
     virtual ~SceneManager();
+
+    /**
+     * Initializes the scene manager.
+     */
     void Init() override;
+
+    /**
+     * Uninitializes the scene manager.
+     */
     void Uninit() override;
+
+    /**
+     * Checks if a given resource type can be stored by the scene manager.
+     * @param t The resource type to check.
+     * @return True if the resource type can be stored, false otherwise.
+     */
     bool CanStore(ResourceType t) override;
+
+    /**
+     * Creates a new local resource of the given type.
+     * @param type The type of resource to create.
+     * @return A pointer to the newly created resource.
+     */
     ResourcePtr CreateLocal(ResourceType type) override;
+
+    /**
+     * Gets the default resource file path for the given resource type.
+     * @param type The resource type.
+     * @return The default resource file path.
+     */
     String GetDefaultResource(ResourceType type) override;
 
+    /**
+     * Gets the currently active scene.
+     * @return A pointer to the current scene.
+     */
     ScenePtr GetCurrentScene();
+
+    /**
+     * Sets the currently active scene.
+     * @param scene A pointer to the new current scene.
+     */
     void SetCurrentScene(const ScenePtr& scene);
 
    private:
-    ScenePtr m_currentScene;
+    ScenePtr m_currentScene; //!< A pointer to the currently active scene.
   };
+
 } // namespace ToolKit


### PR DESCRIPTION
RenderJob's wasn't using skinned characters' aabb override,
Due to that, initial mesh bb was in use either uninitialized or too big which breaks the shadow frustum calculation
This is fixed. Render Job's uses aabb over the characters.

Sometimes Level designers import other scenes and left objects far away from the scene which enlarges the shadow volume too much. Statistically outliers found and removed.

In short,
Outliers and entities with Invalid boundary found and removed.

To do this a command added "CheckSceneHealt" in the future, we will add one more command for assets which will check if the assets have old deprecated data and fixes them.