### PR TITLE
Refresh Workspace Bug

### DIFF
--- a/Editor/Workspace.cpp
+++ b/Editor/Workspace.cpp
@@ -182,7 +182,7 @@ namespace ToolKit
           }
           if (!foundAllRequiredFolders)
           {
-            break;
+            continue;
           }
           std::string dirName = dir.path().filename().u8string();
 


### PR DESCRIPTION
This little typo leads to that; if a project folder is not meet requirements of a valid project, next projects are never indexed.