### PR TITLE
Refactor Resolution selecting menu

### DIFF
--- a/Editor/PluginWindow.cpp
+++ b/Editor/PluginWindow.cpp
@@ -35,12 +35,17 @@ namespace ToolKit
 
     void PluginWindow::RemoveResolutionName(int index)
     {
-      assert(index < 0 ||
-             index < m_screenResolutions.size() && "resolution index invalid");
+      bool canRemove = index > 0 ||
+                       index < m_screenResolutions.size();
 
-      m_screenResolutions.erase(m_screenResolutions.begin() + index);
-      m_emulatorResolutionNames.erase(m_emulatorResolutionNames.begin() +
-                                      index);
+      assert(canRemove && "resolution index invalid");
+      
+      if (canRemove)
+      {
+        m_screenResolutions.erase(m_screenResolutions.begin() + index);
+        m_emulatorResolutionNames.erase(m_emulatorResolutionNames.begin() +
+                                        index);
+      }
     }
 
     void PluginWindow::RemoveResolutionName(const String& name)

--- a/Editor/PluginWindow.cpp
+++ b/Editor/PluginWindow.cpp
@@ -312,6 +312,7 @@ namespace ToolKit
       AddResolutionName("Edit Resolutions");
 
       int lastEnumIndex = m_numEmulatorResNames - 1;
+
       // in order to send to imgui we should convert to ptr array
       const char* enumNames[MaxResolutionNameCnt];
       for (int i = 0; i <= lastEnumIndex; i++) 

--- a/Editor/PluginWindow.cpp
+++ b/Editor/PluginWindow.cpp
@@ -36,7 +36,7 @@ namespace ToolKit
       "Galaxy A51 / A71 (412x914)\0",
     };
 
-    static IVec2 ScreenResolutions[24] =
+    static IVec2 ScreenResolutions[MaxResolutionNameCnt] =
     {
       IVec2(480, 667), // default
       IVec2(375, 667), // Iphone_SE,
@@ -313,7 +313,7 @@ namespace ToolKit
 
       int lastEnumIndex = m_numEmulatorResNames - 1;
       // in order to send to imgui we should conert to ptr array
-      const char* enumNames[24];
+      const char* enumNames[MaxResolutionNameCnt];
       for (int i = 0; i <= lastEnumIndex; i++) 
       {
         enumNames[i] = EmulatorResolutionNames[i];
@@ -356,7 +356,9 @@ namespace ToolKit
         for (int i = m_numDefaultResNames; i < m_numEmulatorResNames; ++i)
         {
           ImGui::PushID(i*333);
-          ImGui::InputText("name", EmulatorResolutionNames[i], 32);
+          ImGui::InputText("name",
+                           EmulatorResolutionNames[i],
+                           MaxResolutionNameWidth);
           ImGui::SameLine();  
           ImGui::InputInt2("size", &ScreenResolutions[i].x);
           ImGui::SameLine();

--- a/Editor/PluginWindow.cpp
+++ b/Editor/PluginWindow.cpp
@@ -385,7 +385,7 @@ namespace ToolKit
       ImGui::SetNextItemWidth(60.0f);
       ImGui::SameLine();
       
-      if (ImGui::DragFloat("##z", &m_settings->Scale, 0.15f, 1.0f))
+      if (ImGui::DragFloat("##z", &m_settings->Scale, 0.05f, 0.0f, 1.0f))
       {
         UpdateSimulationWndSize();
       }

--- a/Editor/PluginWindow.cpp
+++ b/Editor/PluginWindow.cpp
@@ -19,6 +19,8 @@ namespace ToolKit
     static char EmulatorResolutionNames[24][32]
     {
       "Custom Resolutions\0",
+      "Full HD (1080p)\0",
+      "QHD (1440p)\0",
       "iPhone SE (375x667)\0",
       "iPhone XR (414x896)\0",
       "iPhone 12 Pro (390x844)\0",
@@ -320,7 +322,6 @@ namespace ToolKit
         {
           m_resolutionSettingsWindowEnabled = true;
           ImGui::SetNextWindowPos(ImGui::GetMousePos());
-          GetLogger()->WriteConsole(LogType::Warning, "Edit Clicked");
         }
         else
         {

--- a/Editor/PluginWindow.cpp
+++ b/Editor/PluginWindow.cpp
@@ -13,11 +13,60 @@ namespace ToolKit
 {
   namespace Editor
   {
+    constexpr int MaxResolutionNameCnt = 24;
+    constexpr int MaxResolutionNameWidth = 32;
+
+    static char EmulatorResolutionNames[24][32]
+    {
+      "Custom Resolutions\0",
+      "iPhone SE (375x667)\0",
+      "iPhone XR (414x896)\0",
+      "iPhone 12 Pro (390x844)\0",
+      "Pixel 5 (393x851)\0",
+      "Galaxy S20 Ultra (412x915)\0",
+      "Galaxy Note 20 (412x915)\0",
+      "Galaxy Note 20 Ultra (390x844)\0",
+      "Ipad Air  (820x118)\0",
+      "Ipad Mini (768x102)\0",
+      "Surface Pro 7 (912x139)\0",
+      "Surface Duo (540x720)\0",
+      "Galaxy A51 / A71 (412x914)\0",
+    };
+
+    static IVec2 ScreenResolutions[24] =
+    {
+      IVec2(480, 667), // default
+      IVec2(375, 667), // Iphone_SE,
+      IVec2(414, 896), // Iphone_XR,
+      IVec2(390, 844), // Iphone_12_Pro,
+      IVec2(393, 851), // Pixel_5,
+      IVec2(412, 915), // Galaxy_S20_Ultra,
+      IVec2(412, 915), // Galaxy_Note20,
+      IVec2(390, 844), // Galaxy_Note20_Ultra,
+      IVec2(820, 118), // Ipad_Air,
+      IVec2(768, 102), // Ipad_Mini,
+      IVec2(912, 139), // Surface_Pro_7,
+      IVec2(540, 720), // Surface_Duo,
+      IVec2(412, 914)  // Galaxy_A51_A71
+    };
 
     PluginWindow::PluginWindow()
     {
       m_name     = "Plugin";
       m_settings = &g_app->m_simulatorSettings;
+      m_numEmulatorResNames = 0;
+      // calculate number of default resolution names,
+      // greater than 31 means ascii alpha numeric
+      while (EmulatorResolutionNames[m_numEmulatorResNames][0] >= 31)
+        m_numEmulatorResNames++;
+      
+      m_numDefaultResNames = m_numEmulatorResNames;
+      
+      // fill array with valid resolutions
+      for (int i = m_numDefaultResNames; i < MaxResolutionNameCnt; ++i)
+      {
+        ScreenResolutions[i].x = ScreenResolutions[i].y = 500.0f;
+      }
     }
 
     PluginWindow::PluginWindow(XmlNode* node) : PluginWindow()
@@ -26,6 +75,53 @@ namespace ToolKit
     }
 
     PluginWindow::~PluginWindow() {}
+
+    void PluginWindow::AddResolutionName(const char* name)
+    {
+      assert(m_numEmulatorResNames < MaxResolutionNameCnt);
+      int len = 0;
+      while (*name)
+      {
+        EmulatorResolutionNames[m_numEmulatorResNames][len++] = *name++;
+      }
+      // null terminate
+      EmulatorResolutionNames[m_numEmulatorResNames++][len] = '\0'; 
+    }
+
+    void PluginWindow::RemoveResolutionName(int index)
+    {
+      assert(index < 0 || index < m_numEmulatorResNames 
+             && "resolution index invalid");
+      // remove this index
+      int len = 0;
+      while (EmulatorResolutionNames[index][len] != '\0')
+      {
+        EmulatorResolutionNames[index][len++] = '\0';
+      }
+      len = 0;
+      int lastIdx = --m_numEmulatorResNames;
+      // add last name to removed index
+      while (EmulatorResolutionNames[lastIdx][len] != '\0')
+      {
+        char c = EmulatorResolutionNames[lastIdx][len];
+        EmulatorResolutionNames[lastIdx][len] = '\0';
+        EmulatorResolutionNames[index][len++] = c;
+      }
+    }
+
+    void PluginWindow::RemoveResolutionName(const char* name)
+    {
+      for (int i = 0; i < m_numEmulatorResNames; ++i)
+      {
+        if (strcmp(name, EmulatorResolutionNames[i]) == 0)
+        {
+          RemoveResolutionName(i);
+          return;
+        }
+      }
+      GetLogger()->WriteConsole(LogType::Warning, 
+                                "resolution name is not exist!");
+    }
 
     void PluginWindow::Show()
     {
@@ -80,7 +176,12 @@ namespace ToolKit
       {
         ImGui::BeginDisabled(m_simulationModeDisabled);
       }
-      ImGui::Checkbox("Run In Window", &m_settings->Windowed);
+
+      if (ImGui::Button(ICON_FA_SLIDERS, ImVec2(26.0f, 26.0f)))
+      {
+        m_settings->Windowed = !m_settings->Windowed;
+      }
+      
       if (m_simulationModeDisabled)
       {
         ImGui::EndDisabled();
@@ -108,12 +209,9 @@ namespace ToolKit
     {
       // Draw play - pause - stop buttons.
       ImVec2 btnSize = ImVec2(20.0f, 20.0f);
-      if (m_settings->Windowed == false) 
-      {
-        // pick middle point of the window and move left half of the width of action buttons(250.0f)
-        float offset = glm::max(ImGui::GetWindowWidth() * 0.5f - 125.0f, 0.0f);
-        ImGui::SetCursorPosX(offset);
-      }
+      // pick middle point of the window and move left half of the width of action buttons(250.0f)
+      float offset = glm::max(ImGui::GetWindowWidth() * 0.5f - 100.0f, 0.0f);
+      ImGui::SetCursorPosX(offset);
 
       if (g_app->m_gameMod == GameMod::Playing)
       {
@@ -189,23 +287,6 @@ namespace ToolKit
       ImGui::SameLine();
     }
 
-    static const char* EmulatorResolutionNames[] =
-    {
-      "Custom\0"               ,
-      "iPhone SE (375x667)\0",
-      "iPhone XR (414x896)\0",
-      "iPhone 12 Pro (390x844)\0",
-      "Pixel 5 (393x851)\0",
-      "Galaxy S20 Ultra (412x915)\0",
-      "Galaxy Note 20 (412x915)\0",
-      "Galaxy Note 20 Ultra (390x844)\0",
-      "Ipad Air  (820x118)\0",
-      "Ipad Mini (768x102)\0",
-      "Surface Pro 7 (912x139)\0",
-      "Surface Duo (540x720)\0",
-      "Galaxy A51 / A71 (412x914)\0",
-    };
-
     String PluginWindow::EmuResToString(EmulatorResolution emuRes)
     {
       return EmulatorResolutionNames[(uint) emuRes];
@@ -218,79 +299,87 @@ namespace ToolKit
       EmulatorResolution resolution = m_settings->Resolution;
       int resolutionType            = static_cast<int>(resolution);
     
-      static const ImVec2 screenResolutionsLUT[] =
-      {
-        ImVec2(480, 667), // default
-        ImVec2(375, 667), // Iphone_SE,
-        ImVec2(414, 896), // Iphone_XR,
-        ImVec2(390, 844), // Iphone_12_Pro,
-        ImVec2(393, 851), // Pixel_5,
-        ImVec2(412, 915), // Galaxy_S20_Ultra,
-        ImVec2(412, 915), // Galaxy_Note20,
-        ImVec2(390, 844), // Galaxy_Note20_Ultra,
-        ImVec2(820, 118), // Ipad_Air,
-        ImVec2(768, 102), // Ipad_Mini,
-        ImVec2(912, 139), // Surface_Pro_7,
-        ImVec2(540, 720), // Surface_Duo,
-        ImVec2(412, 914)  // Galaxy_A51_A71
-      };
+      ImGui::SetNextItemWidth(
+          ImGui::CalcTextSize(EmulatorResolutionNames[resolutionType]).x*1.2f);
 
-      ImGui::Text("| Resolution");
-      ImGui::SetNextItemWidth(200.0f);
-      ImGui::SameLine();
-      if (ImGui::Combo("##dropdown", &resolutionType, EmulatorResolutionNames, 
-        IM_ARRAYSIZE(EmulatorResolutionNames)))
+      AddResolutionName("Edit Resolutions");
+
+      int lastEnumIndex = m_numEmulatorResNames - 1;
+      const char* enumNames[24];
+      for (int i = 0; i <= lastEnumIndex; i++) 
       {
-        EmulatorResolution resolution =
+        enumNames[i] = EmulatorResolutionNames[i];
+      }
+
+      if (ImGui::Combo("##Resolution",
+                       &resolutionType,
+                       enumNames, 
+                       m_numEmulatorResNames))
+      {
+        if (resolutionType == lastEnumIndex)
+        {
+          m_resolutionSettingsWindowEnabled = true;
+          ImGui::SetNextWindowPos(ImGui::GetMousePos());
+          GetLogger()->WriteConsole(LogType::Warning, "Edit Clicked");
+        }
+        else
+        {
+          EmulatorResolution resolution =
             static_cast<EmulatorResolution>(resolutionType);
         
-        ImVec2 resolutionSize = screenResolutionsLUT[resolutionType];
+          IVec2 resolutionSize   = ScreenResolutions[resolutionType];
 
-        m_settings->Width  = resolutionSize.x;
-        m_settings->Height = resolutionSize.y;
+          m_settings->Width  = (float)resolutionSize.x;
+          m_settings->Height = (float)resolutionSize.y;
       
-        m_settings->Resolution = resolution;
-        UpdateSimulationWndSize();
+          m_settings->Resolution = resolution;
+          UpdateSimulationWndSize();
+        }
       }
-      
-      // Width - Height
-      bool isCustomSized =
-          m_settings->Resolution == EmulatorResolution::Custom;
-      
-      if (isCustomSized)
+      RemoveResolutionName(lastEnumIndex);
+
+      if (m_resolutionSettingsWindowEnabled)
       {
-        ImGui::SameLine();
-        ImGui::Text("Width");
-        ImGui::SetNextItemWidth(70.0f);
-        ImGui::SameLine();
-        if (ImGui::DragFloat("##w", &m_settings->Width, 1.0f, 1.0f, 4096.0f, 
-                            "%.0f"))
+        ImGui::Begin("Edit Resolutions", 
+                     &m_resolutionSettingsWindowEnabled, 
+                     ImGuiWindowFlags_NoScrollWithMouse | 
+                     ImGuiWindowFlags_NoScrollbar |
+                     ImGuiWindowFlags_AlwaysAutoResize);  
+        
+        for (int i = m_numDefaultResNames; i < m_numEmulatorResNames; ++i)
         {
-          UpdateSimulationWndSize();
+          ImGui::PushID(i*333);
+          ImGui::InputText("name", EmulatorResolutionNames[i], 32);
+          ImGui::SameLine();  
+          ImGui::InputInt2("size", &ScreenResolutions[i].x);
+          ImGui::SameLine();
+          if (ImGui::Button(ICON_FA_MINUS)) 
+          {
+            RemoveResolutionName(i);
+          }
+          ImGui::PopID();
         }
-      
+        
+        ImGui::Text("Add New");
         ImGui::SameLine();
-        ImGui::Text("Height");
-        ImGui::SetNextItemWidth(70.0f);
-        ImGui::SameLine();
-      
-        if (ImGui::DragFloat("##h", &m_settings->Height, 1.0f, 1.0f, 4096.0f,
-                             "%.0f"))
+        if (ImGui::Button(ICON_FA_PLUS))
         {
-          UpdateSimulationWndSize();
+          AddResolutionName("new resolution");
         }
+
+        ImGui::End();
       }
+
       // Zoom
       ImGui::SameLine();
       ImGui::Text("Zoom");
-      ImGui::SetNextItemWidth(70.0f);
+      ImGui::SetNextItemWidth(60.0f);
       ImGui::SameLine();
       
-      if (ImGui::SliderFloat("##z", &m_settings->Scale, 0.25f, 1.0f, "x%.2f"))
+      if (ImGui::DragFloat("##z", &m_settings->Scale, 0.15f, 1.0f))
       {
         UpdateSimulationWndSize();
       }
-      
       // Landscape - Portrait Toggle
       ImGui::SameLine();
       ImGui::Text("Rotate");

--- a/Editor/PluginWindow.cpp
+++ b/Editor/PluginWindow.cpp
@@ -312,7 +312,7 @@ namespace ToolKit
       AddResolutionName("Edit Resolutions");
 
       int lastEnumIndex = m_numEmulatorResNames - 1;
-      // in order to send to imgui we should conert to ptr array
+      // in order to send to imgui we should convert to ptr array
       const char* enumNames[MaxResolutionNameCnt];
       for (int i = 0; i <= lastEnumIndex; i++) 
       {

--- a/Editor/PluginWindow.cpp
+++ b/Editor/PluginWindow.cpp
@@ -13,10 +13,11 @@ namespace ToolKit
 {
   namespace Editor
   {
-    constexpr int MaxResolutionNameCnt = 24;
-    constexpr int MaxResolutionNameWidth = 32;
+    const int MaxResolutionNameCnt = 24;
+    const int MaxResolutionNameWidth = 32;
 
-    static char EmulatorResolutionNames[24][32]
+    static char EmulatorResolutionNames[MaxResolutionNameCnt]
+                                       [MaxResolutionNameWidth]
     {
       "Custom Resolutions\0",
       "Full HD (1080p)\0",
@@ -59,12 +60,14 @@ namespace ToolKit
       m_numEmulatorResNames = 0;
       // calculate number of default resolution names,
       // greater than 31 means ascii alpha numeric
-      while (EmulatorResolutionNames[m_numEmulatorResNames][0] >= 31)
+      while (EmulatorResolutionNames[m_numEmulatorResNames][0] >= 31) 
+      {
         m_numEmulatorResNames++;
+      }
       
       m_numDefaultResNames = m_numEmulatorResNames;
       
-      // fill array with valid resolutions
+      // fill remaining array with valid resolutions
       for (int i = m_numDefaultResNames; i < MaxResolutionNameCnt; ++i)
       {
         ScreenResolutions[i].x = ScreenResolutions[i].y = 500.0f;
@@ -211,7 +214,8 @@ namespace ToolKit
     {
       // Draw play - pause - stop buttons.
       ImVec2 btnSize = ImVec2(20.0f, 20.0f);
-      // pick middle point of the window and move left half of the width of action buttons(250.0f)
+      // pick middle point of the window and 
+      // move left half of the width of action buttons(250.0f)
       float offset = glm::max(ImGui::GetWindowWidth() * 0.5f - 100.0f, 0.0f);
       ImGui::SetCursorPosX(offset);
 
@@ -300,13 +304,15 @@ namespace ToolKit
       // Resolution Bar
       EmulatorResolution resolution = m_settings->Resolution;
       int resolutionType            = static_cast<int>(resolution);
-    
+
       ImGui::SetNextItemWidth(
-          ImGui::CalcTextSize(EmulatorResolutionNames[resolutionType]).x*1.2f);
+          ImGui::CalcTextSize(EmulatorResolutionNames[resolutionType]).x *
+          1.3f);
 
       AddResolutionName("Edit Resolutions");
 
       int lastEnumIndex = m_numEmulatorResNames - 1;
+      // in order to send to imgui we should conert to ptr array
       const char* enumNames[24];
       for (int i = 0; i <= lastEnumIndex; i++) 
       {

--- a/Editor/PluginWindow.h
+++ b/Editor/PluginWindow.h
@@ -18,6 +18,8 @@ namespace ToolKit
     enum class EmulatorResolution
     {
       Custom,
+      FullHD,
+      QHD,
       Iphone_SE,
       Iphone_XR,
       Iphone_12_Pro,
@@ -43,6 +45,7 @@ namespace ToolKit
       EmulatorResolution Resolution = EmulatorResolution::Custom;
     };
 
+    
     class PluginWindow : public Window
     {
      public:
@@ -64,12 +67,52 @@ namespace ToolKit
       String EmuResToString(EmulatorResolution emuRes);
       void UpdateCanvas(uint width, uint heigth);
 
-      void AddResolutionName(const char* name);
-      void RemoveResolutionName(const char* name);
+      void AddResolutionName(const String& name);
+      void RemoveResolutionName(const String& name);
       void RemoveResolutionName(int index);
 
-      int m_numEmulatorResNames = 0;
       int m_numDefaultResNames  = 0;
+
+      const int g_MaxResolutionNameCnt = 24;
+      const int g_MaxResolutionNameWidth = 32;
+
+      std::vector<IVec2> m_screenResolutions =
+      {
+        IVec2(480, 667), // default
+        IVec2(1920, 1080), // FullHD
+        IVec2(2048,1080), // QHD
+        IVec2(375, 667), // Iphone_SE,
+        IVec2(414, 896), // Iphone_XR,
+        IVec2(390, 844), // Iphone_12_Pro,
+        IVec2(393, 851), // Pixel_5,
+        IVec2(412, 915), // Galaxy_S20_Ultra,
+        IVec2(412, 915), // Galaxy_Note20,
+        IVec2(390, 844), // Galaxy_Note20_Ultra,
+        IVec2(820, 118), // Ipad_Air,
+        IVec2(768, 102), // Ipad_Mini,
+        IVec2(912, 139), // Surface_Pro_7,
+        IVec2(540, 720), // Surface_Duo,
+        IVec2(412, 914)  // Galaxy_A51_A71
+      };
+
+      std::vector<String> m_emulatorResolutionNames =
+      {
+        "Custom Resolutions\0",
+        "Full HD (1080p)\0",
+        "QHD (1440p)\0",
+        "iPhone SE (375x667)\0",
+        "iPhone XR (414x896)\0",
+        "iPhone 12 Pro (390x844)\0",
+        "Pixel 5 (393x851)\0",
+        "Galaxy S20 Ultra (412x915)\0",
+        "Galaxy Note 20 (412x915)\0",
+        "Galaxy Note 20 Ultra (390x844)\0",
+        "Ipad Air  (820x118)\0",
+        "Ipad Mini (768x102)\0",
+        "Surface Pro 7 (912x139)\0",
+        "Surface Duo (540x720)\0",
+        "Galaxy A51 / A71 (412x914)\0"
+      };
 
      private:
       SimulationSettings* m_settings = nullptr;

--- a/Editor/PluginWindow.h
+++ b/Editor/PluginWindow.h
@@ -64,9 +64,17 @@ namespace ToolKit
       String EmuResToString(EmulatorResolution emuRes);
       void UpdateCanvas(uint width, uint heigth);
 
+      void AddResolutionName(const char* name);
+      void RemoveResolutionName(const char* name);
+      void RemoveResolutionName(int index);
+
+      int m_numEmulatorResNames = 0;
+      int m_numDefaultResNames  = 0;
+
      private:
       SimulationSettings* m_settings = nullptr;
       bool m_simulationModeDisabled  = false;
+      bool m_resolutionSettingsWindowEnabled = false;;
     };
 
   } // namespace Editor

--- a/Editor/UI.h
+++ b/Editor/UI.h
@@ -3,6 +3,7 @@
 #include "ImGui/imgui.h"
 #include "Serialize.h"
 #include "Types.h"
+#include "IconsFontAwesome.h"
 
 #include <functional>
 #include <vector>


### PR DESCRIPTION
Now resolution settings covering much smaller area 
![image](https://user-images.githubusercontent.com/48527900/230879739-14caa3d4-8127-4eb8-ae0c-1732527269d7.png)
position of the action buttons remains same
![image](https://user-images.githubusercontent.com/48527900/230879804-ded0b115-1637-4a7f-bc87-eed23ef1bb51.png)
little window shows up and we are able to add, remove and rename resolutions (for removing the resolution we should click minus button on the right)
![image](https://user-images.githubusercontent.com/48527900/230880073-6956e617-8b47-41f1-8926-23c764f817db.png)
![image](https://user-images.githubusercontent.com/48527900/230882535-edbe532c-1cc9-48ae-84d3-54bd596a11f0.png)

