### PR TITLE
Dev/refactor materials

### DIFF
--- a/Editor/MaterialView.cpp
+++ b/Editor/MaterialView.cpp
@@ -299,27 +299,22 @@ namespace ToolKit
             updateThumbFn();
           }
         }
-        // Display emissive color multiplier if fragment is emissive
-        for (Uniform u : m_mat->m_fragmentShader->m_uniforms)
+
+        if (m_mat->m_emissiveTexture == nullptr)
         {
-          if (u == Uniform::EMISSIVE_COLOR &&
-              m_mat->m_emissiveTexture == nullptr)
+          if (ImGui::ColorEdit3("Emissive Color Multiplier##1",
+                                &m_mat->m_emissiveColor.x,
+                                ImGuiColorEditFlags_HDR |
+                                    ImGuiColorEditFlags_NoLabel |
+                                    ImGuiColorEditFlags_Float))
           {
-            if (ImGui::ColorEdit3("Emissive Color Multiplier##1",
-                                  &m_mat->m_emissiveColor.x,
-                                  ImGuiColorEditFlags_HDR |
-                                      ImGuiColorEditFlags_NoLabel |
-                                      ImGuiColorEditFlags_Float))
-            {
-              updateThumbFn();
-            }
-            ImGui::SameLine();
-            ImGui::Text("Emissive Color");
+            updateThumbFn();
           }
+          ImGui::SameLine();
+          ImGui::Text("Emissive Color");
         }
 
-        if (m_mat->m_materialType == MaterialType::PBR &&
-            m_mat->m_metallicRoughnessTexture == nullptr)
+        if (m_mat->IsPBR() && m_mat->m_metallicRoughnessTexture == nullptr)
         {
           if (ImGui::DragFloat("Metallic",
                                &(m_mat->m_metallic),

--- a/Resources/Engine/Shaders/depthOfFieldFrag.shader
+++ b/Resources/Engine/Shaders/depthOfFieldFrag.shader
@@ -32,7 +32,7 @@
 			if(focusScale == 0.0f){
 				return color;
 			}
-			float centerDepth = -texture(s_texture1, texCoord).r;
+			float centerDepth = -texture(s_texture1, texCoord).z;
 			float centerSize = getBlurSize(centerDepth);
 			float tot = 1.0;
 			float radius = radiusScale;
@@ -40,7 +40,7 @@
 			{
 				vec2 tc = texCoord + vec2(cos(ang), sin(ang)) * uPixelSize * radius;
 				vec3 sampleColor = texture(s_texture0, tc).rgb;
-				float sampleDepth = -texture(s_texture1, tc).r;
+				float sampleDepth = -texture(s_texture1, tc).z;
 				float sampleSize = getBlurSize(sampleDepth);
 				if (sampleDepth > centerDepth)
 					sampleSize = clamp(sampleSize, 0.0, centerSize*2.0);

--- a/Resources/Engine/Shaders/ibl.shader
+++ b/Resources/Engine/Shaders/ibl.shader
@@ -47,19 +47,23 @@
 
 		vec3 IBLSpecularPBR(vec3 normal, vec3 fragToEye, float roughness, vec3 fresnel)
 		{
-			vec3 R = reflect(-fragToEye, normal);
-			float normalDotFragToEye = max(dot(normal, fragToEye), 0.0);
+			vec3 specular = vec3(0.0);
+			if (UseIbl == 1)
+			{
+				vec3 R = reflect(-fragToEye, normal);
+				float normalDotFragToEye = max(dot(normal, fragToEye), 0.0);
 
-			vec3 preFilteredColor = textureLod(s_texture15, R, roughness * float(iblMaxReflectionLod)).rgb;
-			vec2 brdfFactor = texture(s_texture16, vec2(normalDotFragToEye, roughness)).rg;
-			vec3 specular = preFilteredColor * (fresnel * brdfFactor.x + brdfFactor.y);
+				vec3 preFilteredColor = textureLod(s_texture15, R, roughness * float(iblMaxReflectionLod)).rgb;
+				vec2 brdfFactor = texture(s_texture16, vec2(normalDotFragToEye, roughness)).rg;
+				specular = preFilteredColor * (fresnel * brdfFactor.x + brdfFactor.y);
+			}
 
 			return specular;
 		}
 
 		vec3 IBLPBR(vec3 normal, vec3 fragToEye, vec3 albedo, float metallic, float roughness)
 		{
-				// Base reflectivity
+			// Base reflectivity
 			vec3 fresnel = BaseReflectivityPBR(vec3(0.04), albedo, metallic);
 			fresnel = FresnelSchlickRoughness(max(dot(normal, fragToEye), 0.0), fresnel, roughness); 
 
@@ -67,13 +71,12 @@
 			vec3 specular = IBLSpecularPBR(normal, fragToEye, roughness, fresnel);
 			return (diffuse + specular) * IblIntensity;
 		}
-
+		
 		// No specular, only diffuse
 		vec3 IBLPhong(vec3 normal)
 		{
 			return IblDiffuse(normal) * IblIntensity;
 		}
-
 	-->
 	</source>
 </shader>

--- a/ToolKit/GradientSky.cpp
+++ b/ToolKit/GradientSky.cpp
@@ -201,21 +201,27 @@ namespace ToolKit
 
   void GradientSky::GenerateIrradianceCubemap()
   {
-    RenderTask task = {[this](Renderer* renderer) -> void
-                       {
-                         HdriPtr hdr = GetHdri();
-                         hdr->m_irradianceCubemap =
-                             renderer->GenerateEnvIrradianceMap(
-                                 hdr->m_cubemap,
-                                 (uint) GetIrradianceResolutionVal(),
-                                 (uint) GetIrradianceResolutionVal());
+    RenderTask task = {
+        [this](Renderer* renderer) -> void
+        {
+          HdriPtr hdr = GetHdri();
+          uint irRes  = (uint) GetIrradianceResolutionVal();
 
-                         if (m_onInit)
-                         {
-                           m_initialized = true;
-                           m_onInit      = false;
-                         }
-                       }};
+          hdr->m_irradianceCubemap =
+              renderer->GenerateEnvIrradianceMap(hdr->m_cubemap, irRes, irRes);
+
+          hdr->m_prefilteredEnvMap = renderer->GenerateEnvPrefilteredMap(
+              hdr->m_cubemap,
+              irRes,
+              irRes,
+              Renderer::RHIConstants::specularIBLLods);
+
+          if (m_onInit)
+          {
+            m_initialized = true;
+            m_onInit      = false;
+          }
+        }};
 
     GetRenderSystem()->AddRenderTask(task);
   }

--- a/ToolKit/Material.cpp
+++ b/ToolKit/Material.cpp
@@ -162,38 +162,19 @@ namespace ToolKit
 
   void Material::SetDefaultMaterialTypeShaders()
   {
-    auto pbrSanizerFn = [this]() -> void
+    if (IsPBR()) 
     {
-      m_vertexShader = GetShaderManager()->GetDefaultVertexShader();
-
-      if (IsTranslucent())
+      if (IsTranslucent()) 
       {
         m_fragmentShader = GetShaderManager()->GetPbrForwardShader();
       }
-      else
+      else 
       {
         m_fragmentShader = GetShaderManager()->GetPbrDefferedShader();
       }
-    };
 
-    switch (m_materialType)
-    {
-    case MaterialType::PBR:
-      pbrSanizerFn();
-      break;
-    case MaterialType::Custom:
-      if (IsDeferred())
-      {
-        pbrSanizerFn();
-      }
-      break;
-    default:
-      assert(false && "Unknown material type.");
-      break;
+      m_fragmentShader->Init();
     }
-
-    m_fragmentShader->Init();
-    m_vertexShader->Init();
   }
 
   bool Material::IsDeferred()

--- a/ToolKit/Material.cpp
+++ b/ToolKit/Material.cpp
@@ -167,10 +167,8 @@ namespace ToolKit
 
   void Material::SetDefaultMaterialTypeShaders()
   {
-    switch (m_materialType)
+    auto pbrSanizerFn = [this]() -> void
     {
-    case MaterialType::PBR:
-      UnInit();
       m_vertexShader = GetShaderManager()->Create<Shader>(
           ShaderPath("defaultVertex.shader", true));
 
@@ -184,12 +182,26 @@ namespace ToolKit
         m_fragmentShader = GetShaderManager()->Create<Shader>(
             ShaderPath(TK_DEFAULT_DEFERRED_FRAG, true));
       }
+    };
 
-      Init();
+    switch (m_materialType)
+    {
+    case MaterialType::PBR:
+      pbrSanizerFn();
       break;
-    default: // Custom
+    case MaterialType::Custom:
+      if (IsDeferred())
+      {
+        pbrSanizerFn();
+      }
+      break;
+    default:
+      assert(false && "Unknown material type.");
       break;
     }
+
+    m_fragmentShader->Init();
+    m_vertexShader->Init();
   }
 
   bool Material::IsDeferred()

--- a/ToolKit/Material.h
+++ b/ToolKit/Material.h
@@ -11,8 +11,8 @@ namespace ToolKit
   enum class MaterialType
   {
     UNUSEDSLOT_1 = 0,
-    PBR    = 1,
-    Custom = 2
+    PBR          = 1,
+    Custom       = 2
   };
 
   class TK_API Material : public Resource
@@ -31,8 +31,24 @@ namespace ToolKit
     RenderState* GetRenderState();
     void SetRenderState(RenderState* state);
     void SetDefaultMaterialTypeShaders();
+
+    /**
+     * States if the material will use deferred render path.
+     * @returns True if the material will be rendered in deferred path.
+     */
     bool IsDeferred();
+
+    /**
+     * States if the material has transparency.
+     * @returns True if the blend state is SRC_ALPHA_ONE_MINUS_SRC_ALPHA.
+     */
     bool IsTranslucent();
+
+    /**
+     * States if the material is using PBR shaders.
+     * @returns True if the fragmet shader is default PBR shader.
+     */
+    bool IsPBR();
 
     void Serialize(XmlDocument* doc, XmlNode* parent) const override;
     void DeSerialize(XmlDocument* doc, XmlNode* parent) override;

--- a/ToolKit/Pass.cpp
+++ b/ToolKit/Pass.cpp
@@ -149,23 +149,21 @@ namespace ToolKit
   {
     for (const RenderJob& job : jobArray)
     {
-      // Forward pipeline.
-      if (!job.Material->IsDeferred())
+      if (job.Material->IsTranslucent())
       {
-        if (job.Material->IsTranslucent())
-        {
-          translucent.push_back(job);
-        }
-        else
-        {
-          forward.push_back(job);
-        }
+        translucent.push_back(job);
+      }
+      else if (job.Material->IsDeferred())
+      {
+        deferred.push_back(job);
       }
       else
       {
-        // Deferred pipeline.
-        deferred.push_back(job);
+        forward.push_back(job);
       }
+
+      // Sanitize shaders.
+      job.Material->SetDefaultMaterialTypeShaders();
     }
   }
 

--- a/ToolKit/Renderer.cpp
+++ b/ToolKit/Renderer.cpp
@@ -1340,30 +1340,63 @@ namespace ToolKit
 
   void Renderer::SetTexture(ubyte slotIndx, uint textureId)
   {
-    assert(slotIndx < 17 && "You exceed texture slot count");
+    // Texture Slots:
+    // 0 - 5  : 2D textures
+    // 6 - 7  : Cube map textures
+    // 8      : Shadow atlas
+    // 9-14   : 2D textures
+    // 15     : Cube map
+    //
+    // 0 -> Color Texture
+    // 1 -> Emissive Texture
+    // 2 & 3 -> Skinning information
+    // 4 -> Metallic Roughness Texture
+    // 5 -> AO Texture
+    // 6 -> Cubemap
+    // 7 -> Irradiance Map
+    // 8 -> Shadow Atlas
+    // 9 -> Normal map
+    // 15 -> IBL Specular Pre-Filtered Map
+    // 16 -> IBL BRDF Lut
+    //
+    // Deferred Render Pass:
+    // 9 -> gBuffer position texture
+    // 10 -> gBuffer normal texture
+    // 11 -> gBuffer color texture
+    // 12 -> gBuffer emissive texture
+    // 13 -> Light Data Texture
+    // 14 -> gBuffer metallic roughness texture
+    // 17 -> IBL Contribution
+
+    assert(slotIndx < m_rhiSettings::textureSlotCount &&
+           "You exceed texture slot count");
     m_textureSlots[slotIndx] = textureId;
     glActiveTexture(GL_TEXTURE0 + slotIndx);
 
-    static const GLenum textureTypeLut[17] = {
-        GL_TEXTURE_2D,       // 0 -> Color Texture
-        GL_TEXTURE_2D,       // 1 -> Emissive Texture
-        GL_TEXTURE_2D,       // 2 -> Skinning information
-        GL_TEXTURE_2D,       // 3 -> Skinning information
-        GL_TEXTURE_2D,       // 4 -> Metallic Roughness Texture
-        GL_TEXTURE_2D,       // 5 -> AO Texture
-        GL_TEXTURE_CUBE_MAP, // 6 -> Cubemap
-        GL_TEXTURE_CUBE_MAP, // 7 -> Irradiance Map
-        GL_TEXTURE_2D_ARRAY, // 8 -> Shadow Atlas
-        GL_TEXTURE_2D,       // 9 -> Normal map, gbuffer position
-        GL_TEXTURE_2D,       // 10 -> gBuffer normal texture
-        GL_TEXTURE_2D,       // 11 -> gBuffer color texture
-        GL_TEXTURE_2D,       // 12 -> gBuffer emissive texture
-        GL_TEXTURE_2D,       // 13 -> Light Data Texture
-        GL_TEXTURE_CUBE_MAP, // 14 -> gBuffer metallic roughness texture
-        GL_TEXTURE_2D,       // 15 -> IBL Specular Pre-Filtered Map
-        GL_TEXTURE_2D        // 16 -> IBL BRDF Lut
-    };
-    glBindTexture(textureTypeLut[slotIndx], m_textureSlots[slotIndx]);
+    if (slotIndx == m_rhiSettings::shadowAtlasSlot)
+    {
+      glBindTexture(GL_TEXTURE_2D_ARRAY, m_textureSlots[slotIndx]);
+    }
+    else if (slotIndx < 6)
+    {
+      glBindTexture(GL_TEXTURE_2D, m_textureSlots[slotIndx]);
+    }
+    else if (slotIndx < 8)
+    {
+      glBindTexture(GL_TEXTURE_CUBE_MAP, m_textureSlots[slotIndx]);
+    }
+    else if (slotIndx < 15)
+    {
+      glBindTexture(GL_TEXTURE_2D, m_textureSlots[slotIndx]);
+    }
+    else if (slotIndx < 16)
+    {
+      glBindTexture(GL_TEXTURE_CUBE_MAP, m_textureSlots[slotIndx]);
+    }
+    else if (slotIndx < 17)
+    {
+      glBindTexture(GL_TEXTURE_2D, m_textureSlots[slotIndx]);
+    }
   }
 
   void Renderer::SetShadowAtlas(TexturePtr shadowAtlas)

--- a/ToolKit/Renderer.cpp
+++ b/ToolKit/Renderer.cpp
@@ -1340,63 +1340,30 @@ namespace ToolKit
 
   void Renderer::SetTexture(ubyte slotIndx, uint textureId)
   {
-    // Texture Slots:
-    // 0 - 5  : 2D textures
-    // 6 - 7  : Cube map textures
-    // 8      : Shadow atlas
-    // 9-14   : 2D textures
-    // 15     : Cube map
-    //
-    // 0 -> Color Texture
-    // 1 -> Emissive Texture
-    // 2 & 3 -> Skinning information
-    // 4 -> Metallic Roughness Texture
-    // 5 -> AO Texture
-    // 6 -> Cubemap
-    // 7 -> Irradiance Map
-    // 8 -> Shadow Atlas
-    // 9 -> Normal map
-    // 15 -> IBL Specular Pre-Filtered Map
-    // 16 -> IBL BRDF Lut
-    //
-    // Deferred Render Pass:
-    // 9 -> gBuffer position texture
-    // 10 -> gBuffer normal texture
-    // 11 -> gBuffer color texture
-    // 12 -> gBuffer emissive texture
-    // 13 -> Light Data Texture
-    // 14 -> gBuffer metallic roughness texture
-    // 17 -> IBL Contribution
-
-    assert(slotIndx < m_rhiSettings::textureSlotCount &&
-           "You exceed texture slot count");
+    assert(slotIndx < 17 && "You exceed texture slot count");
     m_textureSlots[slotIndx] = textureId;
     glActiveTexture(GL_TEXTURE0 + slotIndx);
 
-    if (slotIndx == m_rhiSettings::shadowAtlasSlot)
-    {
-      glBindTexture(GL_TEXTURE_2D_ARRAY, m_textureSlots[slotIndx]);
-    }
-    else if (slotIndx < 6)
-    {
-      glBindTexture(GL_TEXTURE_2D, m_textureSlots[slotIndx]);
-    }
-    else if (slotIndx < 8)
-    {
-      glBindTexture(GL_TEXTURE_CUBE_MAP, m_textureSlots[slotIndx]);
-    }
-    else if (slotIndx < 15)
-    {
-      glBindTexture(GL_TEXTURE_2D, m_textureSlots[slotIndx]);
-    }
-    else if (slotIndx < 16)
-    {
-      glBindTexture(GL_TEXTURE_CUBE_MAP, m_textureSlots[slotIndx]);
-    }
-    else if (slotIndx < 17)
-    {
-      glBindTexture(GL_TEXTURE_2D, m_textureSlots[slotIndx]);
-    }
+    static const GLenum textureTypeLut[17] = {
+        GL_TEXTURE_2D,       // 0 -> Color Texture
+        GL_TEXTURE_2D,       // 1 -> Emissive Texture
+        GL_TEXTURE_2D,       // 2 -> Skinning information
+        GL_TEXTURE_2D,       // 3 -> Skinning information
+        GL_TEXTURE_2D,       // 4 -> Metallic Roughness Texture
+        GL_TEXTURE_2D,       // 5 -> AO Texture
+        GL_TEXTURE_CUBE_MAP, // 6 -> Cubemap
+        GL_TEXTURE_CUBE_MAP, // 7 -> Irradiance Map
+        GL_TEXTURE_2D_ARRAY, // 8 -> Shadow Atlas
+        GL_TEXTURE_2D,       // 9 -> Normal map, gbuffer position
+        GL_TEXTURE_2D,       // 10 -> gBuffer normal texture
+        GL_TEXTURE_2D,       // 11 -> gBuffer color texture
+        GL_TEXTURE_2D,       // 12 -> gBuffer emissive texture
+        GL_TEXTURE_2D,       // 13 -> Light Data Texture
+        GL_TEXTURE_2D,       // 14 -> gBuffer metallic roughness texture
+        GL_TEXTURE_CUBE_MAP, // 15 -> IBL Specular Pre-Filtered Map
+        GL_TEXTURE_2D        // 16 -> IBL BRDF Lut
+    };
+    glBindTexture(textureTypeLut[slotIndx], m_textureSlots[slotIndx]);
   }
 
   void Renderer::SetShadowAtlas(TexturePtr shadowAtlas)

--- a/ToolKit/Resource.cpp
+++ b/ToolKit/Resource.cpp
@@ -109,7 +109,7 @@ namespace ToolKit
     return val;
   }
 
-  String Resource::GetFile() const { return m_file; }
+  const String& Resource::GetFile() const { return m_file; }
 
   const String& Resource::GetSerializeFile() const
   {

--- a/ToolKit/Resource.h
+++ b/ToolKit/Resource.h
@@ -65,7 +65,7 @@ namespace ToolKit
      */
     static String DeserializeRef(XmlNode* parent);
 
-    String GetFile() const;
+    const String& GetFile() const;
     /**
      * Returns _missingFile if not empty to prevent override actual resource
      * file.

--- a/ToolKit/Shader.cpp
+++ b/ToolKit/Shader.cpp
@@ -16,6 +16,10 @@
 namespace ToolKit
 {
 
+#define TK_DEFAULT_DEFERRED_FRAG "deferredRenderFrag.shader"
+#define TK_DEFAULT_FORWARD_FRAG  "defaultFragment.shader"
+#define TK_DEFAULT_VERTEX_SHADER "defaultVertex.shader"
+
   Shader::Shader() {}
 
   Shader::Shader(String file) : Shader() { SetFile(file); }
@@ -439,7 +443,18 @@ namespace ToolKit
 
   ShaderManager::~ShaderManager() {}
 
-  void ShaderManager::Init() { ResourceManager::Init(); }
+  void ShaderManager::Init()
+  {
+    ResourceManager::Init();
+
+    m_pbrDefferedShaderFile   = ShaderPath(TK_DEFAULT_DEFERRED_FRAG, true);
+    m_pbrForwardShaderFile    = ShaderPath(TK_DEFAULT_FORWARD_FRAG, true);
+    m_defaultVertexShaderFile = ShaderPath(TK_DEFAULT_VERTEX_SHADER, true);
+
+    Create<Shader>(m_pbrDefferedShaderFile);
+    Create<Shader>(m_pbrForwardShaderFile);
+    Create<Shader>(m_defaultVertexShaderFile);
+  }
 
   bool ShaderManager::CanStore(ResourceType t)
   {
@@ -449,6 +464,32 @@ namespace ToolKit
   ResourcePtr ShaderManager::CreateLocal(ResourceType type)
   {
     return ResourcePtr(new Shader());
+  }
+
+  ShaderPtr ShaderManager::GetDefaultVertexShader()
+  {
+    return std::static_pointer_cast<Shader>(
+        m_storage[m_defaultVertexShaderFile]);
+  }
+
+  ShaderPtr ShaderManager::GetPbrDefferedShader()
+  {
+    return std::static_pointer_cast<Shader>(m_storage[m_pbrDefferedShaderFile]);
+  }
+
+  ShaderPtr ShaderManager::GetPbrForwardShader()
+  {
+    return std::static_pointer_cast<Shader>(m_storage[m_pbrForwardShaderFile]);
+  }
+
+  const String& ShaderManager::PbrDefferedShaderFile()
+  {
+    return m_pbrDefferedShaderFile;
+  }
+
+  const String& ShaderManager::PbrForwardShaderFile()
+  {
+    return m_pbrForwardShaderFile;
   }
 
 } // namespace ToolKit

--- a/ToolKit/Shader.h
+++ b/ToolKit/Shader.h
@@ -149,6 +149,18 @@ namespace ToolKit
     void Init() override;
     bool CanStore(ResourceType t) override;
     ResourcePtr CreateLocal(ResourceType type) override;
+
+    ShaderPtr GetDefaultVertexShader();
+    ShaderPtr GetPbrDefferedShader();
+    ShaderPtr GetPbrForwardShader();
+
+    const String& PbrDefferedShaderFile();
+    const String& PbrForwardShaderFile();
+
+   private:
+    String m_pbrDefferedShaderFile;
+    String m_pbrForwardShaderFile;
+    String m_defaultVertexShaderFile;
   };
 
 } // namespace ToolKit

--- a/ToolKit/Texture.cpp
+++ b/ToolKit/Texture.cpp
@@ -464,6 +464,7 @@ namespace ToolKit
     {
       m_cubemap->UnInit();
       m_irradianceCubemap->UnInit();
+      m_prefilteredEnvMap->UnInit();
     }
 
     Texture::UnInit();


### PR DESCRIPTION
Every PBR material shows rougness and metalness value as long as the underlying shader is PBR,
independent of render pipeline ( Both forward and deferred has same PBR material )

- Gradient Sky also generates specular irradiance map, previously it was using default ibl's irradiance, which was causing visual glitches, false reflections.
- When ibl is not in use, specular is calculated as 0 in the ibl shader, previously it was only effecting diffuse irradiance.