### PR TITLE
Problem Fix.

### DIFF
--- a/Editor/EditorCamera.cpp
+++ b/Editor/EditorCamera.cpp
@@ -125,18 +125,17 @@ namespace ToolKit
           {
             if (Viewport* av = g_app->GetViewport(g_3dViewport))
             {
+              m_posessed = !m_posessed;
               if (m_posessed)
-              {
-                av->AttachCamera(NULL_HANDLE);
-                ParamPoses().m_name = "Poses";
-              }
-              else
               {
                 av->AttachCamera(GetIdVal());
                 ParamPoses().m_name = "Free";
               }
-
-              m_posessed = !m_posessed;
+              else
+              {
+                av->DetachCamera();
+                ParamPoses().m_name = "Poses";
+              }
             }
           },
           CameraCategory.Name,

--- a/Editor/EditorCamera.cpp
+++ b/Editor/EditorCamera.cpp
@@ -125,19 +125,18 @@ namespace ToolKit
           {
             if (Viewport* av = g_app->GetViewport(g_3dViewport))
             {
+              m_posessed = !m_posessed;
+
               if (m_posessed)
               {
-                av->AttachCamera(m_changedCam);
-                ParamPoses().m_name = "Poses";
-              }
-              else
-              {
-                m_changedCam = av->GetCamera()->GetIdVal();
                 av->AttachCamera(GetIdVal());
                 ParamPoses().m_name = "Free";
               }
-
-              m_posessed = !m_posessed;
+              else
+              {
+                av->DetachCamera();
+                ParamPoses().m_name = "Poses";
+              }
             }
           },
           CameraCategory.Name,

--- a/Editor/EditorCamera.cpp
+++ b/Editor/EditorCamera.cpp
@@ -125,17 +125,19 @@ namespace ToolKit
           {
             if (Viewport* av = g_app->GetViewport(g_3dViewport))
             {
-              m_posessed = !m_posessed;
               if (m_posessed)
               {
-                av->AttachCamera(GetIdVal());
-                ParamPoses().m_name = "Free";
+                av->AttachCamera(m_changedCam);
+                ParamPoses().m_name = "Poses";
               }
               else
               {
-                av->DetachCamera();
-                ParamPoses().m_name = "Poses";
+                m_changedCam = av->GetCamera()->GetIdVal();
+                av->AttachCamera(GetIdVal());
+                ParamPoses().m_name = "Free";
               }
+
+              m_posessed = !m_posessed;
             }
           },
           CameraCategory.Name,

--- a/Editor/EditorCamera.h
+++ b/Editor/EditorCamera.h
@@ -26,7 +26,8 @@ namespace ToolKit
       void ParameterConstructor();
 
      private:
-      bool m_posessed = false;
+      bool m_posessed = false;  
+      ULongID m_changedCam = NULL_HANDLE;
     };
 
   } // namespace Editor

--- a/Editor/EditorCamera.h
+++ b/Editor/EditorCamera.h
@@ -27,7 +27,6 @@ namespace ToolKit
 
      private:
       bool m_posessed = false;  
-      ULongID m_changedCam = NULL_HANDLE;
     };
 
   } // namespace Editor

--- a/Editor/EditorScene.cpp
+++ b/Editor/EditorScene.cpp
@@ -202,33 +202,30 @@ namespace ToolKit
         {
           AddToSelection(id, true);
         }
-        else // Add, make current or toggle selection.
+        else if (IsSelected(id)) // Add, make current or toggle selection.
         {
-          if (IsSelected(id))
+          if (GetSelectedEntityCount() > 1)
           {
-            if (GetSelectedEntityCount() > 1)
+            if (entities.size() == 1)
             {
-              if (entities.size() == 1)
+              if (IsCurrentSelection(id))
               {
-                if (IsCurrentSelection(id))
-                {
-                  RemoveFromSelection(id);
-                }
-                else
-                {
-                  MakeCurrentSelection(id, false);
-                }
+                RemoveFromSelection(id);
               }
-            }
-            else
-            {
-              RemoveFromSelection(id);
+              else
+              {
+                MakeCurrentSelection(id, false);
+              }
             }
           }
           else
           {
-            AddToSelection(id, true);
+            RemoveFromSelection(id);
           }
+        }
+        else
+        {
+          AddToSelection(id, true);
         }
       }
 

--- a/ToolKit/UIManager.cpp
+++ b/ToolKit/UIManager.cpp
@@ -185,6 +185,7 @@ namespace ToolKit
   void UIManager::UpdateLayers(float deltaTime, Viewport* viewport)
   {
     // Swap viewport camera with ui camera.
+    ULongID viewportOldAttachedId = viewport->GetAttachedCamera();
     viewport->AttachCamera(m_uiCamera->GetIdVal());
 
     // Update viewports with ui camera.
@@ -201,7 +202,7 @@ namespace ToolKit
       }
     }
 
-    viewport->DetachCamera();
+    viewport->AttachCamera(viewportOldAttachedId);
   }
 
   void UIManager::ResizeLayers(Viewport* viewport)

--- a/ToolKit/UIManager.cpp
+++ b/ToolKit/UIManager.cpp
@@ -185,8 +185,7 @@ namespace ToolKit
   void UIManager::UpdateLayers(float deltaTime, Viewport* viewport)
   {
     // Swap viewport camera with ui camera.
-    ULongID attachmentSwap = NULL_HANDLE;
-    viewport->SwapCamera(&m_uiCamera, attachmentSwap);
+    viewport->AttachCamera(m_uiCamera->GetIdVal());
 
     // Update viewports with ui camera.
     for (auto& viewLayerArray : m_viewportIdLayerArrayMap)
@@ -202,7 +201,7 @@ namespace ToolKit
       }
     }
 
-    viewport->SwapCamera(&m_uiCamera, attachmentSwap);
+    viewport->DetachCamera();
   }
 
   void UIManager::ResizeLayers(Viewport* viewport)

--- a/ToolKit/Viewport.cpp
+++ b/ToolKit/Viewport.cpp
@@ -36,28 +36,13 @@ namespace ToolKit
 
   void ViewportBase::SetCamera(Camera* cam)
   {
-    SafeDel(m_camera);
+    if (m_camera != nullptr)
+    {
+      // delete the camera and remove it from the scene
+      GetSceneManager()->GetCurrentScene()->RemoveEntity(m_camera->GetIdVal());
+      SafeDel(m_camera);
+    }
     m_camera         = cam;
-    m_attachedCamera = NULL_HANDLE;
-  }
-
-  void ViewportBase::SwapCamera(Camera** cam, ULongID& attachment)
-  {
-    if (cam == nullptr)
-    {
-      return;
-    }
-
-    if (*cam == nullptr)
-    {
-      return;
-    }
-
-    Camera* tmp      = *cam;
-    *cam             = m_camera;
-    m_camera         = tmp;
-
-    attachment       = m_attachedCamera;
     m_attachedCamera = NULL_HANDLE;
   }
 
@@ -233,6 +218,10 @@ namespace ToolKit
   }
 
   void Viewport::AttachCamera(ULongID camId) { m_attachedCamera = camId; }
+
+  void Viewport::DetachCamera() { m_attachedCamera = NULL_HANDLE; }
+
+  ULongID Viewport::GetAttachedCamera() { return m_attachedCamera; }
 
   float Viewport::GetBillboardScale()
   {

--- a/ToolKit/Viewport.h
+++ b/ToolKit/Viewport.h
@@ -43,14 +43,6 @@ namespace ToolKit
      */
     virtual void SetCamera(Camera* cam);
 
-    /**
-     * Swaps the Viewport's Camera and Detach any camera if any. If the
-     * provided camera is nullptr, function doesn't do anything.
-     * @param cam is the camera to swap with.
-     * @param attachment is set to current camera attachment for swap backup.
-     */
-    void SwapCamera(Camera** cam, ULongID& attachment);
-
    public:
     /**
      * Viewport identifier. Unique trough the runtime.
@@ -170,6 +162,17 @@ namespace ToolKit
      * Stores the Camera id that the scene will use while rendering.
      */
     virtual void AttachCamera(ULongID camID); // Attach a camera from the scene
+    
+    /**
+     * Gets attached camera.
+     * @return if attached camera index exist, index of camera otherwise NULL_HANDLE
+     */
+    virtual ULongID GetAttachedCamera(); 
+
+    /**
+      * detach attached camera and use default camera
+      */
+    virtual void DetachCamera();
 
     /**
      * Returns the Billboard scale value based on viewport data. This scale is


### PR DESCRIPTION
Deleted SwapCamera function it was too complex for such a simple task and it has two major issues:

-function was setting currently attached camera to NULL_HANDLE.

-function was not care if an camera attached to it. it was swapping m_camera but
 if an attached camera exist it should've been swapping that attached camera instead.