### PR TITLE
Dev/bloom fixes

### DIFF
--- a/Editor/MaterialView.cpp
+++ b/Editor/MaterialView.cpp
@@ -286,12 +286,12 @@ namespace ToolKit
             updateThumbFn();
           }
           if (ImGui::DragFloat("Alpha",
-                               &m_mat->m_alpha,
+                               &m_mat->GetAlpha(),
                                1.0f / 256.0f,
                                0.0f,
                                1.0f))
           {
-            bool isForward = m_mat->m_alpha < 0.99f;
+            bool isForward = m_mat->GetAlpha() < 0.99f;
             renderState->blendFunction =
                 isForward ? BlendFunction::SRC_ALPHA_ONE_MINUS_SRC_ALPHA
                           : BlendFunction::NONE;
@@ -352,7 +352,7 @@ namespace ToolKit
           renderState->blendFunction = (BlendFunction) blendMode;
           if (renderState->blendFunction == BlendFunction::NONE)
           {
-            m_mat->m_alpha = 1.0f;
+            m_mat->SetAlpha(1.0f);
           }
 
           m_mat->m_dirty = true;

--- a/Editor/PropInspector.cpp
+++ b/Editor/PropInspector.cpp
@@ -37,12 +37,11 @@ namespace ToolKit
               ImGui::IsKeyPressed(ImGuiKey_Tab));
     }
 
-    void View::DropZone(
-        uint fallbackIcon,
-        const String& file,
-        std::function<void(DirectoryEntry& entry)> dropAction,
-        const String& dropName,
-        bool isEditable)
+    void View::DropZone(uint fallbackIcon,
+                        const String& file,
+                        std::function<void(DirectoryEntry& entry)> dropAction,
+                        const String& dropName,
+                        bool isEditable)
     {
       DirectoryEntry dirEnt;
 
@@ -190,8 +189,7 @@ namespace ToolKit
     PreviewViewport::PreviewViewport(uint width, uint height)
         : EditorViewport((float) width, (float) height)
     {
-      m_renderPass            = std::make_shared<SceneRenderer>();
-      // m_renderPass->m_params.Gfx.BloomEnabled = false;
+      m_previewRenderer       = std::make_shared<SceneRenderer>();
 
       DirectionalLight* light = new DirectionalLight();
       light->SetPCFRadiusVal(0.001f);
@@ -209,18 +207,18 @@ namespace ToolKit
       directionComp->Yaw(glm::radians(-20.0f));
       directionComp->Pitch(glm::radians(-20.0f));
 
-      m_light                                 = light;
-      m_renderPass->m_params.Cam              = GetCamera();
-      m_renderPass->m_params.ClearFramebuffer = true;
-      m_renderPass->m_params.Lights           = {m_light};
-      m_renderPass->m_params.MainFramebuffer  = m_framebuffer;
-      m_renderPass->m_params.Scene            = std::make_shared<Scene>();
+      m_light                                      = light;
+      m_previewRenderer->m_params.Cam              = GetCamera();
+      m_previewRenderer->m_params.ClearFramebuffer = true;
+      m_previewRenderer->m_params.Lights           = {m_light};
+      m_previewRenderer->m_params.MainFramebuffer  = m_framebuffer;
+      m_previewRenderer->m_params.Scene            = std::make_shared<Scene>();
     }
 
     PreviewViewport::~PreviewViewport()
     {
       SafeDel(m_light);
-      m_renderPass = nullptr;
+      m_previewRenderer = nullptr;
     }
 
     void PreviewViewport::Show()
@@ -232,11 +230,10 @@ namespace ToolKit
 
       HandleStates();
       DrawCommands();
-      
-      m_renderPass->m_params.Gfx = GetEngineSettings().PostProcessing;
-      m_renderPass->m_params.Gfx.DepthOfFieldEnabled = false;
-      m_renderPass->m_params.MainFramebuffer = m_framebuffer;
-      const EntityRawPtrArray& entities      = GetScene()->GetEntities();
+
+      m_previewRenderer->m_params.MainFramebuffer = m_framebuffer;
+
+      const EntityRawPtrArray& entities           = GetScene()->GetEntities();
       for (const Entity* ntt : entities)
       {
         MeshComponentPtr mc = ntt->GetMeshComponent();
@@ -255,7 +252,7 @@ namespace ToolKit
         }
       }
 
-      GetRenderSystem()->AddRenderTask(m_renderPass);
+      GetRenderSystem()->AddRenderTask(m_previewRenderer);
 
       // Render color attachment as rounded image
       FramebufferSettings fbSettings = m_framebuffer->GetSettings();
@@ -263,7 +260,7 @@ namespace ToolKit
       Vec2 currentCursorPos = Vec2(ImGui::GetWindowContentRegionMin()) +
                               Vec2(ImGui::GetCursorPos()) +
                               Vec2(ImGui::GetWindowPos());
-      
+
       ImGui::Dummy(imageSize);
 
       ImGui::GetWindowDrawList()->AddImageRounded(
@@ -279,7 +276,7 @@ namespace ToolKit
 
     ScenePtr PreviewViewport::GetScene()
     {
-      return m_renderPass->m_params.Scene;
+      return m_previewRenderer->m_params.Scene;
     }
 
     void PreviewViewport::ResetCamera()
@@ -367,13 +364,13 @@ namespace ToolKit
 
             if (view->m_fontIcon.size() > 0)
             {
-              if (ImGui::Button(view->m_fontIcon.data(), ImVec2(27,25)))
+              if (ImGui::Button(view->m_fontIcon.data(), ImVec2(27, 25)))
               {
                 m_activeView = (ViewType) viewIndx;
               }
             }
             else if (ImGui::ImageButton(Convert2ImGuiTexture(view->m_viewIcn),
-                                   sidebarIconSize))
+                                        sidebarIconSize))
             {
               m_activeView = (ViewType) viewIndx;
             }

--- a/Editor/PropInspector.cpp
+++ b/Editor/PropInspector.cpp
@@ -215,7 +215,6 @@ namespace ToolKit
       m_renderPass->m_params.Lights           = {m_light};
       m_renderPass->m_params.MainFramebuffer  = m_framebuffer;
       m_renderPass->m_params.Scene            = std::make_shared<Scene>();
-      m_renderPass->m_params.Gfx.DepthOfFieldEnabled = false;
     }
 
     PreviewViewport::~PreviewViewport()
@@ -233,7 +232,9 @@ namespace ToolKit
 
       HandleStates();
       DrawCommands();
-
+      
+      m_renderPass->m_params.Gfx = GetEngineSettings().PostProcessing;
+      m_renderPass->m_params.Gfx.DepthOfFieldEnabled = false;
       m_renderPass->m_params.MainFramebuffer = m_framebuffer;
       const EntityRawPtrArray& entities      = GetScene()->GetEntities();
       for (const Entity* ntt : entities)

--- a/Editor/PropInspector.h
+++ b/Editor/PropInspector.h
@@ -58,8 +58,8 @@ namespace ToolKit
       void ResizeWindow(uint width, uint height) override;
 
      private:
-      SceneRendererPtr m_renderPass = nullptr;
-      Light* m_light                = nullptr;
+      SceneRendererPtr m_previewRenderer = nullptr;
+      Light* m_light                     = nullptr;
     };
 
     typedef View* ViewRawPtr;

--- a/Editor/SingleMaterialPass.cpp
+++ b/Editor/SingleMaterialPass.cpp
@@ -42,7 +42,7 @@ namespace ToolKit
         renderer->m_overrideMat->m_emissiveColor   = mat->m_emissiveColor;
         renderer->m_overrideMat->m_cubeMap         = mat->m_cubeMap;
         renderer->m_overrideMat->m_color           = mat->m_color;
-        renderer->m_overrideMat->m_alpha           = mat->m_alpha;
+        renderer->m_overrideMat->SetAlpha(mat->GetAlpha());
         renderer->m_overrideMat->Init();
 
         renderer->Render(job, m_params.ForwardParams.Cam, lightList);

--- a/Import/import.cpp
+++ b/Import/import.cpp
@@ -646,7 +646,7 @@ namespace ToolKit
           material->Get(AI_MATKEY_COLOR_TRANSPARENT, transparency);
         }
       }
-      tMaterial->m_alpha    = transparency;
+      tMaterial->SetAlpha(transparency);
 
       aiBlendMode blendFunc = aiBlendMode_Default;
       if (material->Get(AI_MATKEY_BLEND_FUNC, blendFunc) == aiReturn_SUCCESS)

--- a/ToolKit/BloomPass.cpp
+++ b/ToolKit/BloomPass.cpp
@@ -68,75 +68,83 @@ namespace ToolKit
     }
 
     // Downsample Pass
-    for (int i = 0; i < m_params.iterationCount; i++)
     {
-      // Calculate current and previous resolutions
-
-      float powVal = glm::pow(2.0f, float(i + 1));
-      const Vec2 factor(1.0f / powVal);
-      const UVec2 curRes             = Vec2(mainRes) * factor;
-
-      powVal                         = glm::pow(2.0f, float(i));
-      const Vec2 prevRes             = Vec2(mainRes) * Vec2((1.0f / powVal));
-
-      // Find previous framebuffer & RT
-      FramebufferPtr prevFramebuffer = m_tempFrameBuffers[i];
-      TexturePtr prevRt              = prevFramebuffer->GetAttachment(
-          Framebuffer::Attachment::ColorAttachment0);
-
-      // Set pass' shader and parameters
-      m_pass->m_params.FragmentShader = m_downsampleShader;
-
-      int passIndx                    = i + 1;
-      m_downsampleShader->SetShaderParameter("passIndx",
-                                             ParameterVariant(passIndx));
-
       m_downsampleShader->SetShaderParameter(
           "threshold",
           ParameterVariant(m_params.minThreshold));
 
-      m_downsampleShader->SetShaderParameter("srcResolution",
-                                             ParameterVariant(prevRes));
+      GetLogger()->WriteConsole(LogType::Error,
+                                "threshold %f",
+                                m_params.minThreshold);
 
-      GetRenderer()->SetTexture(0, prevRt->m_textureId);
+      for (int i = 0; i < m_params.iterationCount; i++)
+      {
+        // Calculate current and previous resolutions
 
-      // Set pass parameters
-      m_pass->m_params.ClearFrameBuffer = true;
-      m_pass->m_params.FrameBuffer      = m_tempFrameBuffers[i + 1];
-      m_pass->m_params.BlendFunc        = BlendFunction::NONE;
+        float powVal = glm::pow(2.0f, float(i + 1));
+        const Vec2 factor(1.0f / powVal);
+        const UVec2 curRes             = Vec2(mainRes) * factor;
 
-      RenderSubPass(m_pass);
+        powVal                         = glm::pow(2.0f, float(i));
+        const Vec2 prevRes             = Vec2(mainRes) * Vec2((1.0f / powVal));
+
+        // Find previous framebuffer & RT
+        FramebufferPtr prevFramebuffer = m_tempFrameBuffers[i];
+        TexturePtr prevRt              = prevFramebuffer->GetAttachment(
+            Framebuffer::Attachment::ColorAttachment0);
+
+        // Set pass' shader and parameters
+        m_pass->m_params.FragmentShader = m_downsampleShader;
+
+        int passIndx                    = i + 1;
+        m_downsampleShader->SetShaderParameter("passIndx",
+                                               ParameterVariant(passIndx));
+
+        m_downsampleShader->SetShaderParameter("srcResolution",
+                                               ParameterVariant(prevRes));
+
+        GetRenderer()->SetTexture(0, prevRt->m_textureId);
+
+        // Set pass parameters
+        m_pass->m_params.ClearFrameBuffer = true;
+        m_pass->m_params.FrameBuffer      = m_tempFrameBuffers[i + 1];
+        m_pass->m_params.BlendFunc        = BlendFunction::NONE;
+
+        RenderSubPass(m_pass);
+      }
     }
 
     // Upsample Pass
-    const float filterRadius = 0.002f;
-    for (int i = m_params.iterationCount; i > 0; i--)
     {
-      m_pass->m_params.FragmentShader = m_upsampleShader;
+      const float filterRadius = 0.002f;
       m_upsampleShader->SetShaderParameter("filterRadius",
                                            ParameterVariant(filterRadius));
 
-      FramebufferPtr prevFramebuffer = m_tempFrameBuffers[i];
-      TexturePtr prevRt              = prevFramebuffer->GetAttachment(
-          Framebuffer::Attachment::ColorAttachment0);
-      GetRenderer()->SetTexture(0, prevRt->m_textureId);
-
-      m_pass->m_params.BlendFunc        = BlendFunction::ONE_TO_ONE;
-      m_pass->m_params.ClearFrameBuffer = false;
-      m_pass->m_params.FrameBuffer      = m_tempFrameBuffers[i - 1];
       m_upsampleShader->SetShaderParameter("intensity", ParameterVariant(1.0f));
 
-      RenderSubPass(m_pass);
+      for (int i = m_params.iterationCount; i > 0; i--)
+      {
+        m_pass->m_params.FragmentShader = m_upsampleShader;
+
+        FramebufferPtr prevFramebuffer  = m_tempFrameBuffers[i];
+        TexturePtr prevRt               = prevFramebuffer->GetAttachment(
+            Framebuffer::Attachment::ColorAttachment0);
+        GetRenderer()->SetTexture(0, prevRt->m_textureId);
+
+        m_pass->m_params.BlendFunc        = BlendFunction::ONE_TO_ONE;
+        m_pass->m_params.ClearFrameBuffer = false;
+        m_pass->m_params.FrameBuffer      = m_tempFrameBuffers[i - 1];
+
+        RenderSubPass(m_pass);
+      }
     }
 
     // Merge Pass
     {
       m_pass->m_params.FragmentShader = m_upsampleShader;
-      m_upsampleShader->SetShaderParameter("filterRadius",
-                                           ParameterVariant(filterRadius));
 
-      FramebufferPtr prevFramebuffer = m_tempFrameBuffers[0];
-      TexturePtr prevRt              = prevFramebuffer->GetAttachment(
+      FramebufferPtr prevFramebuffer  = m_tempFrameBuffers[0];
+      TexturePtr prevRt               = prevFramebuffer->GetAttachment(
           Framebuffer::Attachment::ColorAttachment0);
       GetRenderer()->SetTexture(0, prevRt->m_textureId);
 
@@ -147,6 +155,10 @@ namespace ToolKit
       m_upsampleShader->SetShaderParameter(
           "intensity",
           ParameterVariant(m_params.intensity));
+
+      GetLogger()->WriteConsole(LogType::Error,
+                                "intensity %f",
+                                m_params.intensity);
 
       RenderSubPass(m_pass);
     }

--- a/ToolKit/BloomPass.cpp
+++ b/ToolKit/BloomPass.cpp
@@ -56,6 +56,10 @@ namespace ToolKit
       m_downsampleShader->SetShaderParameter("srcResolution",
                                              ParameterVariant(mainRes));
 
+      m_downsampleShader->SetShaderParameter(
+          "threshold",
+          ParameterVariant(m_params.minThreshold));
+
       TexturePtr prevRt = m_params.FrameBuffer->GetAttachment(
           Framebuffer::Attachment::ColorAttachment0);
 
@@ -69,14 +73,6 @@ namespace ToolKit
 
     // Downsample Pass
     {
-      m_downsampleShader->SetShaderParameter(
-          "threshold",
-          ParameterVariant(m_params.minThreshold));
-
-      GetLogger()->WriteConsole(LogType::Error,
-                                "threshold %f",
-                                m_params.minThreshold);
-
       for (int i = 0; i < m_params.iterationCount; i++)
       {
         // Calculate current and previous resolutions
@@ -155,10 +151,6 @@ namespace ToolKit
       m_upsampleShader->SetShaderParameter(
           "intensity",
           ParameterVariant(m_params.intensity));
-
-      GetLogger()->WriteConsole(LogType::Error,
-                                "intensity %f",
-                                m_params.intensity);
 
       RenderSubPass(m_pass);
     }

--- a/ToolKit/BloomPass.cpp
+++ b/ToolKit/BloomPass.cpp
@@ -170,6 +170,12 @@ namespace ToolKit
         glm::min(m_params.iterationCount,
                  glm::min(maxIterCounts.x, maxIterCounts.y));
 
+    if (m_params.iterationCount < 0)
+    {
+      m_invalidRenderParams = true;
+      return;
+    }
+
     m_tempTextures.resize(m_params.iterationCount + 1);
     m_tempFrameBuffers.resize(m_params.iterationCount + 1);
 

--- a/ToolKit/GBufferPass.cpp
+++ b/ToolKit/GBufferPass.cpp
@@ -190,10 +190,10 @@ namespace ToolKit
       m_gBufferMaterial->m_normalMap    = activeMaterial->m_normalMap;
       m_gBufferMaterial->m_cubeMap      = activeMaterial->m_cubeMap;
       m_gBufferMaterial->m_color        = activeMaterial->m_color;
-      m_gBufferMaterial->m_alpha        = activeMaterial->m_alpha;
       m_gBufferMaterial->m_metallic     = activeMaterial->m_metallic;
       m_gBufferMaterial->m_roughness    = activeMaterial->m_roughness;
       m_gBufferMaterial->m_materialType = activeMaterial->m_materialType;
+      m_gBufferMaterial->SetAlpha(activeMaterial->GetAlpha());
       m_gBufferMaterial->Init();
 
       renderer->m_overrideMat = m_gBufferMaterial;

--- a/ToolKit/Material.cpp
+++ b/ToolKit/Material.cpp
@@ -177,6 +177,18 @@ namespace ToolKit
     }
   }
 
+  void Material::SetAlpha(float val)
+  {
+    val = glm::clamp(val, 0.0f, 1.0f);
+    m_alpha = val;
+    bool isForward = m_alpha < 0.99f;
+    m_renderState.blendFunction =
+                isForward ? BlendFunction::SRC_ALPHA_ONE_MINUS_SRC_ALPHA
+                : BlendFunction::NONE;    
+  }
+
+  float& Material::GetAlpha() { return m_alpha; }
+
   bool Material::IsDeferred()
   {
     if (IsTranslucent())

--- a/ToolKit/Material.h
+++ b/ToolKit/Material.h
@@ -31,6 +31,17 @@ namespace ToolKit
     RenderState* GetRenderState();
     void SetRenderState(RenderState* state);
     void SetDefaultMaterialTypeShaders();
+    
+    /**
+      * Acces to alpha value (opacity)
+      * @returns Referance to alpha value
+      */
+    float& GetAlpha();
+
+    /**
+      * Set the alpha value (opacity)
+      */
+    void SetAlpha(float val);
 
     /**
      * States if the material will use deferred render path.
@@ -68,11 +79,11 @@ namespace ToolKit
     Vec3 m_emissiveColor;
     float m_metallic            = 0.2f;
     float m_roughness           = 0.5f;
-    float m_alpha               = 1.0f;
 
     MaterialType m_materialType = MaterialType::Custom;
 
    private:
+    float m_alpha               = 1.0f;
     RenderState m_renderState;
   };
 

--- a/ToolKit/Renderer.cpp
+++ b/ToolKit/Renderer.cpp
@@ -830,7 +830,7 @@ namespace ToolKit
           if (m_mat == nullptr)
             break;
 
-          Vec4 color = Vec4(m_mat->m_color, m_mat->m_alpha);
+          Vec4 color = Vec4(m_mat->m_color, m_mat->GetAlpha());
           if (m_mat->GetRenderState()->blendFunction == BlendFunction::NONE)
           {
             color.a = 1.0f;
@@ -923,7 +923,7 @@ namespace ToolKit
           GLint loc =
               glGetUniformLocation(program->m_handle,
                                    GetUniformName(Uniform::COLOR_ALPHA));
-          glUniform1f(loc, m_mat->m_alpha);
+          glUniform1f(loc, m_mat->GetAlpha());
         }
         break;
         case Uniform::IBL_ROTATION:

--- a/ToolKit/ShadowPass.cpp
+++ b/ToolKit/ShadowPass.cpp
@@ -112,7 +112,7 @@ namespace ToolKit
         MaterialPtr material = job.Material;
         renderer->m_overrideMat->SetRenderState(material->GetRenderState());
         renderer->m_overrideMat->UnInit();
-        renderer->m_overrideMat->m_alpha          = material->m_alpha;
+        renderer->m_overrideMat->SetAlpha(material->GetAlpha());
         renderer->m_overrideMat->m_diffuseTexture = material->m_diffuseTexture;
         renderer->m_overrideMat->GetRenderState()->blendFunction =
             BlendFunction::NONE;


### PR DESCRIPTION
iteration count may be -1 which was causing out of index. ( due to screen resoulution arriving 0 - 1 )
This case is eliminated.

threshold was beign set after the filter pass, 
so the bloom pass was using whatever the previous settings for threshold in the shader
and for down sampling it was using the new threshold.

I have moved threshold settings before the filter pass to fix the issue.