### PR TITLE
Assert Fix

### DIFF
--- a/ToolKit/Animation.cpp
+++ b/ToolKit/Animation.cpp
@@ -420,6 +420,11 @@ namespace ToolKit
         continue;
       }
 
+      if (!record->m_entity)
+      {
+        continue;
+      }
+
       AnimRecord::State state = record->m_state;
       if (state == AnimRecord::State::Play)
       {


### PR DESCRIPTION
In debug mode, sometimes entities in the scene is destructed before AnimRecords. animationplayer tries to play animation of non-existing entity and that causes error.