### PR TITLE
OutlinerRemoveBugSolved

### DIFF
--- a/Editor/Mod.cpp
+++ b/Editor/Mod.cpp
@@ -515,19 +515,12 @@ namespace ToolKit
       {
         return NullSignal;
       }
-
       // Gather the selection hierarchy.
       EntityRawPtrArray deleteList;
       g_app->GetCurrentScene()->GetSelectedEntities(deleteList);
 
-      EntityRawPtrArray roots;
-      GetRootEntities(deleteList, roots);
-
-      deleteList.clear();
-      for (Entity* e : roots)
+      for (Entity* e : deleteList)
       {
-        // Gather hierarchy from parent to child.
-        deleteList.push_back(e);
         if (e->GetType() == EntityType::Entity_Prefab)
         {
           // Entity will already delete its own childs


### PR DESCRIPTION
We used to select, selected entities parents and delete them, 
now we are not doing that. deleting only selected entities and their childs.