### PR TITLE
Parameter variant category fix

### DIFF
--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -69,7 +69,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;zlibstatic.lib;minizip.lib;SDL2main.lib;SDL2.lib;OpenGL32.lib;ToolKit_d.lib;imgui_d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;SDL2main.lib;SDL2.lib;OpenGL32.lib;ToolKit_d.lib;imgui_d.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/ToolKit/ParameterBlock.cpp
+++ b/ToolKit/ParameterBlock.cpp
@@ -726,14 +726,15 @@ namespace ToolKit
           {
             if (var.m_name == memberVar.m_name)
             {
-              memberVar = var;
-              isFound   = true;
+              memberVar.m_var = var.m_var;
+              isFound         = true;
               break;
             }
           }
 
-          if (!isFound && var.m_category.Name == CustomDataCategory.Name)
+          if (!isFound)
           {
+            var.m_category = CustomDataCategory;
             Add(var);
           }
         }

--- a/ToolKit/ParameterBlock.h
+++ b/ToolKit/ParameterBlock.h
@@ -226,6 +226,7 @@ namespace ToolKit
    */
   class TK_API ParameterVariant : public ParameterVariantBase
   {
+    friend class ParameterBlock;
    public:
     /**
      * Enums for supported ParameterVariant types. These types are used for


### PR DESCRIPTION
Reads the variant value from file and insert it to decleared parameter's value spot.
The idea is to not read decelerations from file because they are fixed with variable itself.
Once a variable declared we expect it to maintain its declarative sections but the value will change.