### PR TITLE
Fix Android OpenGL Erros

### DIFF
--- a/Editor/Gizmo.cpp
+++ b/Editor/Gizmo.cpp
@@ -82,8 +82,8 @@ namespace ToolKit
       parentMesh->UnInit();
 
       // Billboard
-      Quad quad;
-      MeshPtr meshPtr    = quad.GetMeshComponent()->GetMeshVal();
+      QuadPtr quad = MakeNewPtr<Quad>();
+      MeshPtr meshPtr    = quad->GetMeshComponent()->GetMeshVal();
       MaterialPtr matPtr = GetMaterialManager()->GetCopyOfUnlitMaterial();
       matPtr->UnInit();
       matPtr->m_diffuseTexture =
@@ -92,29 +92,24 @@ namespace ToolKit
       matPtr->GetRenderState()->alphaMaskTreshold = 0.1f;
       matPtr->Init();
       meshPtr->m_material = matPtr;
+      meshPtr->Init();
       parentMesh->m_subMeshes.push_back(meshPtr);
 
       // Lines
       VertexArray vertices;
-      vertices.resize(12);
+      vertices.resize(8);
 
-      vertices[0].pos.z                       = -0.3f;
-      vertices[1].pos.z                       = -0.7f;
+      vertices[0].pos.x                       = 0.2f;
+      vertices[1].pos.x                       = 0.5f;
 
-      vertices[2].pos.z                       = 0.3f;
-      vertices[3].pos.z                       = 0.7f;
+      vertices[2].pos.x                       = -0.2f;
+      vertices[3].pos.x                       = -0.5f;
 
-      vertices[4].pos.x                       = 0.3f;
-      vertices[5].pos.x                       = 0.7f;
+      vertices[4].pos.y                       = 0.2f;
+      vertices[5].pos.y                       = 0.5f;
 
-      vertices[6].pos.x                       = -0.3f;
-      vertices[7].pos.x                       = -0.7f;
-
-      vertices[8].pos.y                       = 0.3f;
-      vertices[9].pos.y                       = 0.7f;
-
-      vertices[10].pos.y                      = -0.3f;
-      vertices[11].pos.y                      = -0.7f;
+      vertices[6].pos.y                      = -0.2f;
+      vertices[7].pos.y                      = -0.5f;
 
       MaterialPtr newMaterial                 = GetMaterialManager()->GetCopyOfUnlitColorMaterial();
       newMaterial->m_color                    = Vec3(0.1f, 0.1f, 0.1f);
@@ -122,6 +117,8 @@ namespace ToolKit
 
       parentMesh->m_clientSideVertices        = vertices;
       parentMesh->m_material                  = newMaterial;
+
+      parentMesh->Init();
 
       parentMesh->CalculateAABB();
     }

--- a/ToolKit/AdditiveLightingPass.cpp
+++ b/ToolKit/AdditiveLightingPass.cpp
@@ -264,13 +264,9 @@ namespace ToolKit
       RenderSubPass(m_fullQuadPass);
     }
 
-    // swap depth texture of gbuffer and this. because main depth buffer is empty now
-    // and we need depth buffer for mesh lights
-    DepthTexturePtr mainDepth = m_params.MainFramebuffer->GetDepthTexture();
-    m_params.MainFramebuffer->AttachDepthTexture(m_params.GBufferFramebuffer->GetDepthTexture());
+    renderer->CopyFrameBuffer(m_params.GBufferFramebuffer, m_params.MainFramebuffer, GraphicBitFields::DepthBits);
     // we need to use gbuffers depth in this pass in order to make proper depth test
-    m_lightingFrameBuffer->AttachDepthTexture(m_params.GBufferFramebuffer->GetDepthTexture());
-    m_params.GBufferFramebuffer->AttachDepthTexture(mainDepth);
+    renderer->CopyFrameBuffer(m_params.GBufferFramebuffer, m_lightingFrameBuffer, GraphicBitFields::DepthBits);
 
     m_lightingShader->SetShaderParameter("isScreenSpace", ParameterVariant(0));
     renderer->EnableDepthWrite(false);

--- a/ToolKit/ForwardPreProcessPass.cpp
+++ b/ToolKit/ForwardPreProcessPass.cpp
@@ -89,6 +89,7 @@ namespace ToolKit
 
     using FAttachment                 = Framebuffer::Attachment;
 
+    m_framebuffer->ClearAttachments();
     m_framebuffer->SetAttachment(FAttachment::ColorAttachment0, m_params.gLinearRt);
     m_framebuffer->SetAttachment(FAttachment::ColorAttachment1, m_params.gNormalRt);
     m_framebuffer->AttachDepthTexture(m_params.gFrameBuffer->GetDepthTexture());

--- a/ToolKit/ForwardPreProcessPass.cpp
+++ b/ToolKit/ForwardPreProcessPass.cpp
@@ -24,6 +24,8 @@
  * SOFTWARE.
  */
 
+// Purpose of this pass is exporting forward depths and normals before SSAO pass
+
 #include "ForwardPreProcessPass.h"
 
 #include "Shader.h"
@@ -39,6 +41,9 @@ namespace ToolKit
 
     m_framebuffer            = MakeNewPtr<Framebuffer>();
     m_linearMaterial         = MakeNewPtr<Material>();
+    m_normalRt               = MakeNewPtr<RenderTarget>();
+    m_linearDepthRt          = MakeNewPtr<RenderTarget>();
+
     m_linearMaterial->m_vertexShader   = vertexShader;
     m_linearMaterial->m_fragmentShader = fragmentShader;
     m_linearMaterial->Init();
@@ -49,6 +54,9 @@ namespace ToolKit
   void ForwardPreProcess::Render()
   {
     Renderer* renderer                      = GetRenderer();
+    // copy normal and linear depth from gbuffer to this
+    renderer->CopyTexture(m_params.gNormalRt, m_normalRt);
+    renderer->CopyTexture(m_params.gLinearRt, m_linearDepthRt);
 
     const auto renderLinearDepthAndNormalFn = [this, renderer](RenderJobArray& renderJobArray)
     {
@@ -68,7 +76,9 @@ namespace ToolKit
     };
 
     renderLinearDepthAndNormalFn(m_params.OpaqueJobs);
-    renderLinearDepthAndNormalFn(m_params.TranslucentJobs);
+    // currently transparent objects are not rendered to export screen space normals or linear depth
+    // we want SSAO and DOF to effect on opaque objects only
+    // renderLinearDepthAndNormalFn(m_params.TranslucentJobs); 
   }
 
   void ForwardPreProcess::PreRender()
@@ -79,19 +89,26 @@ namespace ToolKit
     uint height = (uint) m_params.gLinearRt->m_height;
 
     m_framebuffer->Init({width, height, false, false});
-
+    
     RenderTargetSettigs oneChannelSet = {};
     oneChannelSet.WarpS               = GraphicTypes::UVClampToEdge;
     oneChannelSet.WarpT               = GraphicTypes::UVClampToEdge;
-    oneChannelSet.InternalFormat      = GraphicTypes::FormatRGB32F;
-    oneChannelSet.Format              = GraphicTypes::FormatRGB;
+    oneChannelSet.InternalFormat      = GraphicTypes::FormatRGBA16F;
+    oneChannelSet.Format              = GraphicTypes::FormatRGBA;
     oneChannelSet.Type                = GraphicTypes::TypeFloat;
+    
+    m_normalRt->m_settings            = oneChannelSet;
+    m_normalRt->ReconstructIfNeeded(width, height);
+    
+    oneChannelSet.InternalFormat      = GraphicTypes::FormatRGBA32F;
+    m_linearDepthRt->m_settings       = oneChannelSet;
+    m_linearDepthRt->ReconstructIfNeeded(width, height);
 
     using FAttachment                 = Framebuffer::Attachment;
 
     m_framebuffer->ClearAttachments();
-    m_framebuffer->SetAttachment(FAttachment::ColorAttachment0, m_params.gLinearRt);
-    m_framebuffer->SetAttachment(FAttachment::ColorAttachment1, m_params.gNormalRt);
+    m_framebuffer->SetAttachment(FAttachment::ColorAttachment0, m_linearDepthRt);
+    m_framebuffer->SetAttachment(FAttachment::ColorAttachment1, m_normalRt);
     m_framebuffer->AttachDepthTexture(m_params.gFrameBuffer->GetDepthTexture());
 
     Renderer* renderer = GetRenderer();

--- a/ToolKit/ForwardPreProcessPass.h
+++ b/ToolKit/ForwardPreProcessPass.h
@@ -47,6 +47,9 @@ namespace ToolKit
     ForwardRenderPassParams m_params;
     MaterialPtr m_linearMaterial = nullptr;
     FramebufferPtr m_framebuffer = nullptr;
+    
+    RenderTargetPtr m_normalRt      = nullptr;
+    RenderTargetPtr m_linearDepthRt = nullptr;
   };
 
   typedef std::shared_ptr<ForwardPreProcess> ForwardPreProcessPassPtr;

--- a/ToolKit/Framebuffer.cpp
+++ b/ToolKit/Framebuffer.cpp
@@ -121,7 +121,7 @@ namespace ToolKit
     GLenum attachment = dt->m_stencil ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT;
 
     // Attach depth buffer to FBO
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, dt->m_textureId);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, dt->m_textureId, 0);
 
     // Check if framebuffer is complete
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
@@ -257,7 +257,7 @@ namespace ToolKit
     GLenum attachment = m_settings.depthStencil ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT;
 
     // Detach depth buffer from FBO
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
 
     if (m_settings.useDefaultDepth)
     {

--- a/ToolKit/Framebuffer.cpp
+++ b/ToolKit/Framebuffer.cpp
@@ -121,7 +121,7 @@ namespace ToolKit
     GLenum attachment = dt->m_stencil ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT;
 
     // Attach depth buffer to FBO
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, dt->m_textureId, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, dt->m_textureId);
 
     // Check if framebuffer is complete
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
@@ -238,9 +238,7 @@ namespace ToolKit
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &lastFBO);
     glBindFramebuffer(GL_FRAMEBUFFER, m_fboId);
     GLenum check = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-#ifndef __ANDROID__ // TODO This will be gone after fixing rendering to mipmap levels for ibl specular
     assert(check == GL_FRAMEBUFFER_COMPLETE && "Framebuffer incomplete");
-#endif
     glBindFramebuffer(GL_FRAMEBUFFER, lastFBO);
   }
 
@@ -257,7 +255,7 @@ namespace ToolKit
     GLenum attachment = m_settings.depthStencil ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT;
 
     // Detach depth buffer from FBO
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, 0);
 
     if (m_settings.useDefaultDepth)
     {

--- a/ToolKit/GBufferPass.cpp
+++ b/ToolKit/GBufferPass.cpp
@@ -63,7 +63,6 @@ namespace ToolKit
     // Note: A32 is not used, it didn't work on Android devices when we bind it to frame buffer
     m_gLinearDepthRt = MakeNewPtr<RenderTarget>(1024, 1024, gBufferRenderTargetSettings);
 
-
     gBufferRenderTargetSettings.InternalFormat      = GraphicTypes::FormatRG16F;
     gBufferRenderTargetSettings.Format              = GraphicTypes::FormatRG;
 
@@ -177,7 +176,10 @@ namespace ToolKit
     renderer->SetCameraLens(m_params.Camera);
   }
 
-  void GBufferPass::PostRender() { Pass::PostRender(); }
+  void GBufferPass::PostRender()
+  {
+    Pass::PostRender(); 
+  }
 
   void GBufferPass::Render()
   {

--- a/ToolKit/GBufferPass.h
+++ b/ToolKit/GBufferPass.h
@@ -33,8 +33,8 @@ namespace ToolKit
 
   struct GBufferPassParams
   {
-    RenderJobArray RendeJobs = {};
-    CameraPtr Camera         = nullptr;
+    RenderJobArray RendeJobs       = {};
+    CameraPtr Camera               = nullptr;
   };
 
   class TK_API GBufferPass : public RenderPass

--- a/ToolKit/Renderer.cpp
+++ b/ToolKit/Renderer.cpp
@@ -203,11 +203,6 @@ namespace ToolKit
     Mesh* mesh = job.Mesh;
     activateSkinning(mesh->IsSkinned());
 
-    if (mesh->m_vertexCount == 0)
-    {
-      return;
-    }
-
     RenderState* rs = m_mat->GetRenderState();
     SetRenderState(rs);
     FeedUniforms(prg);

--- a/ToolKit/Renderer.cpp
+++ b/ToolKit/Renderer.cpp
@@ -203,6 +203,11 @@ namespace ToolKit
     Mesh* mesh = job.Mesh;
     activateSkinning(mesh->IsSkinned());
 
+    if (mesh->m_vertexCount == 0)
+    {
+      return;
+    }
+
     RenderState* rs = m_mat->GetRenderState();
     SetRenderState(rs);
     FeedUniforms(prg);

--- a/ToolKit/SceneRenderer.cpp
+++ b/ToolKit/SceneRenderer.cpp
@@ -83,7 +83,7 @@ namespace ToolKit
 
     // Gbuffer for deferred render
     m_passArray.push_back(m_gBufferPass);
-
+    
     m_passArray.push_back(m_forwardPreProcessPass);
 
     // SSAO pass
@@ -118,6 +118,7 @@ namespace ToolKit
     {
       m_passArray.push_back(m_bloomPass);
     }
+
     if (m_params.Gfx.DepthOfFieldEnabled)
     {
       m_passArray.push_back(m_dofPass);
@@ -211,8 +212,8 @@ namespace ToolKit
     m_lightingPass->m_params.AOTexture                = m_params.Gfx.SSAOEnabled ? m_ssaoPass->m_ssaoTexture : nullptr;
 
     m_ssaoPass->m_params.GPositionBuffer              = m_gBufferPass->m_gPosRt;
-    m_ssaoPass->m_params.GNormalBuffer                = m_gBufferPass->m_gNormalRt;
-    m_ssaoPass->m_params.GLinearDepthBuffer           = m_gBufferPass->m_gLinearDepthRt;
+    m_ssaoPass->m_params.GNormalBuffer                = m_forwardPreProcessPass->m_normalRt;
+    m_ssaoPass->m_params.GLinearDepthBuffer           = m_forwardPreProcessPass->m_linearDepthRt;
     m_ssaoPass->m_params.Cam                          = m_params.Cam;
     m_ssaoPass->m_params.Radius                       = m_params.Gfx.SSAORadius;
     m_ssaoPass->m_params.spread                       = m_params.Gfx.SSAOSpread;
@@ -239,7 +240,7 @@ namespace ToolKit
 
     // DoF pass
     m_dofPass->m_params.ColorRt    = m_params.MainFramebuffer->GetAttachment(Framebuffer::Attachment::ColorAttachment0);
-    m_dofPass->m_params.DepthRt    = m_gBufferPass->m_gLinearDepthRt;
+    m_dofPass->m_params.DepthRt    = m_forwardPreProcessPass->m_linearDepthRt;
     m_dofPass->m_params.focusPoint = m_params.Gfx.FocusPoint;
     m_dofPass->m_params.focusScale = m_params.Gfx.FocusScale;
     m_dofPass->m_params.blurQuality     = m_params.Gfx.DofQuality;

--- a/ToolKit/Texture.cpp
+++ b/ToolKit/Texture.cpp
@@ -209,18 +209,11 @@ namespace ToolKit
     m_height    = height;
     m_stencil   = stencil;
 
-    GLint currId;
-    glGetIntegerv(GL_TEXTURE_BINDING_2D, &currId);
-
-    glGenTextures(1, &m_textureId);
-    glBindTexture(GL_TEXTURE_2D, m_textureId);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-    glBindTexture(GL_TEXTURE_2D, currId);
+    // Create a default depth, depth-stencil buffer
+    glGenRenderbuffers(1, &m_textureId);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_textureId);
+    GLenum component = stencil ? GL_DEPTH24_STENCIL8 : GL_DEPTH_COMPONENT24;
+    glRenderbufferStorage(GL_RENDERBUFFER, component, m_width, m_height);
   }
 
   void DepthTexture::UnInit()
@@ -229,7 +222,7 @@ namespace ToolKit
     {
       return;
     }
-    glDeleteTextures(1, &m_textureId);
+    glDeleteRenderbuffers(1, &m_textureId);
 
     m_textureId = 0;
   }


### PR DESCRIPTION
Merged with https://github.com/Oyun-Teknolojileri/ToolKit/pull/229.

We were writing on gbuffers render targets but now we copy from gbuffer and use it later in SSAO and DOF
this way we fix additive lighting as well, because now we are using correct normals when we render behind the translucent objects

![image_2023-09-29_163820690](https://github.com/Oyun-Teknolojileri/ToolKit/assets/78075948/ac54815f-26a0-49e8-b667-33dfd7d7158d)