### PR TITLE
Game Plugin Callbacks

### DIFF
--- a/Editor/App.h
+++ b/Editor/App.h
@@ -58,7 +58,7 @@ namespace ToolKit
 
       /**
        * Clears all the data cached for current project / scene. Required to clear
-       * all referenced objects before switching projects or stoping the play session.
+       * all referenced objects before switching projects or stopping the play session.
        */
       void ClearSession();
 

--- a/Template/Codes/Game.cpp
+++ b/Template/Codes/Game.cpp
@@ -26,4 +26,12 @@ namespace ToolKit
 
   void Game::OnUnload(XmlDocumentPtr state) {}
 
+  void Game::OnPlay() {}
+
+  void Game::OnPause() {}
+
+  void Game::OnResume() {}
+
+  void Game::OnStop() {}
+
 } // namespace ToolKit

--- a/Template/Codes/Game.h
+++ b/Template/Codes/Game.h
@@ -21,6 +21,10 @@ namespace ToolKit
     void Frame(float deltaTime) override;
     void OnLoad(XmlDocumentPtr state) override;
     void OnUnload(XmlDocumentPtr state) override;
+    void OnPlay() override;
+    void OnPause() override;
+    void OnResume() override;
+    void OnStop() override;
   };
 
   extern Game* g_game;

--- a/ToolKit/Plugin.h
+++ b/ToolKit/Plugin.h
@@ -129,6 +129,26 @@ namespace ToolKit
      */
     PluginType GetType() { return PluginType::Game; }
 
+    /**
+     * This callback gets called when the play session started for the first time.
+     */
+    virtual void OnPlay()   = 0;
+
+    /**
+     * This callback gets called when the play session stopped.
+     */
+    virtual void OnPause()  = 0;
+
+    /**
+     * This callback gets called play session continue after paused.
+     */
+    virtual void OnResume() = 0;
+
+    /**
+     * This callback gets called play session continue stopped.
+     */
+    virtual void OnStop()   = 0;
+
    protected:
     /**
      * Viewport where the game played on.


### PR DESCRIPTION
Add callbacks for onplay, onpause, onresume and onstop
also fixes the crash when switching between projects.