### PR TITLE
Fix Crashes When Changing Scene or Deleting Object

### DIFF
--- a/ToolKit/GpuProgram.h
+++ b/ToolKit/GpuProgram.h
@@ -52,7 +52,7 @@ namespace ToolKit
    public:
     uint m_handle = 0;
     ShaderPtrArray m_shaders;
-    Material* m_activeMaterial;
+    ULongID m_activeMaterialID = 0;
 
    private:
     std::unordered_map<Uniform, int> m_uniformLocations;

--- a/ToolKit/MobileSceneRenderPath.cpp
+++ b/ToolKit/MobileSceneRenderPath.cpp
@@ -129,7 +129,6 @@ namespace ToolKit
 
     const EntityPtrArray& allDrawList = m_params.Scene->GetEntities();
 
-    m_renderData.jobs;
     RenderJobProcessor::CreateRenderJobs(allDrawList,
                                          m_renderData.jobs,
                                          m_updatedLights,

--- a/ToolKit/Pass.cpp
+++ b/ToolKit/Pass.cpp
@@ -132,6 +132,7 @@ namespace ToolKit
       }
     }
 
+    jobArray.clear();
     jobArray.resize(size); // at least.
 
     // Construct jobs.

--- a/ToolKit/Renderer.cpp
+++ b/ToolKit/Renderer.cpp
@@ -778,9 +778,9 @@ namespace ToolKit
     {
       updateMaterial = true;
     }
-    else if (Material* mat = program->m_activeMaterial)
+    else if (ULongID matID = program->m_activeMaterialID)
     {
-      updateMaterial = !mat->IsSame(m_mat);
+      updateMaterial = matID != m_mat->GetIdVal();
     }
     else
     {
@@ -792,7 +792,7 @@ namespace ToolKit
       if (m_mat != nullptr)
       {
         m_mat->m_updateGPUUniforms = false;
-        program->m_activeMaterial  = m_mat;
+        program->m_activeMaterialID  = m_mat->GetIdVal();
 
         int uniformLoc             = program->GetUniformLocation(Uniform::COLOR);
         if (uniformLoc != -1)


### PR DESCRIPTION
- If a the compared material has been created afterwards of the programs last deleted active material, we rely on that the deleted id will not overlap with the new created id. (This chance is too small but it is still on the table)
- Clear render jobs before creating in CreateRenderJobs()