### PR TITLE
Bounding Box Calc fix

### DIFF
--- a/Editor/Anchor.cpp
+++ b/Editor/Anchor.cpp
@@ -101,7 +101,7 @@ namespace ToolKit
       Vec3 pos;
       float w = 0, h = 0;
       {
-        const BoundingBox bb = canvasPanel->GetAABB(true);
+        const BoundingBox bb = canvasPanel->GetBoundingBox(true);
         w                    = bb.GetWidth();
         h                    = bb.GetHeight();
         pos                  = Vec3(bb.min.x, bb.max.y, pos.z);
@@ -379,7 +379,7 @@ namespace ToolKit
       rayInObj.direction = Vec4(ray.direction, 0.0f);
 
       m_mesh->CalculateAABB();
-      return RayBoxIntersection(rayInObj, m_mesh->m_aabb, t);
+      return RayBoxIntersection(rayInObj, m_mesh->m_boundingBox, t);
     }
 
     Mat4 AnchorHandle::GetTransform() const

--- a/Editor/AnchorMod.cpp
+++ b/Editor/AnchorMod.cpp
@@ -408,7 +408,7 @@ namespace ToolKit
         if (parent->IsA<Canvas>())
         {
           Canvas* canvasPanel  = parent->As<Canvas>();
-          const BoundingBox bb = canvasPanel->GetAABB(true);
+          const BoundingBox bb = canvasPanel->GetBoundingBox(true);
           w                    = bb.GetWidth();
           h                    = bb.GetHeight();
         }

--- a/Editor/App.cpp
+++ b/Editor/App.cpp
@@ -684,7 +684,7 @@ namespace ToolKit
 
       if (!GetCurrentScene()->GetBillboard(entity))
       {
-        cam->FocusToBoundingBox(entity->GetAABB(true), 1.1f);
+        cam->FocusToBoundingBox(entity->GetBoundingBox(true), 1.1f);
       }
       else
       {
@@ -1593,10 +1593,12 @@ namespace ToolKit
     void App::CreateEditorEntities()
     {
       // Create editor objects.
-      m_cursor = MakeNewPtr<Cursor>();
-      m_origin = MakeNewPtr<Axis3d>();
+      m_cursor   = MakeNewPtr<Cursor>();
+      m_origin   = MakeNewPtr<Axis3d>();
+      m_dbgArrow = MakeNewPtr<Arrow2d>();
+      m_dbgArrow->Generate(AxisLabel::X);
 
-      m_grid   = MakeNewPtr<Grid>();
+      m_grid = MakeNewPtr<Grid>();
       m_grid->Resize(g_max2dGridSize, AxisLabel::ZX, 0.020f, 3.0);
 
       m_2dGrid         = MakeNewPtr<Grid>();

--- a/Editor/ComponentView.cpp
+++ b/Editor/ComponentView.cpp
@@ -85,7 +85,7 @@ namespace ToolKit
       MeshComponentPtr meshComp = overrideComp->OwnerEntity()->GetComponent<MeshComponent>();
       if (meshComp && ImGui::Button("Update from MeshComponent"))
       {
-        overrideComp->SetAABB(meshComp->GetAABB());
+        overrideComp->SetBoundingBox(meshComp->GetBoundingBox());
       }
       ImGui::EndDisabled();
     }

--- a/Editor/EditorRenderer.cpp
+++ b/Editor/EditorRenderer.cpp
@@ -219,7 +219,7 @@ namespace ToolKit
 
         if (app->m_showSelectionBoundary && ntt->IsDrawable())
         {
-          app->m_perFrameDebugObjects.push_back(CreateBoundingBoxDebugObject(ntt->GetAABB(true)));
+          app->m_perFrameDebugObjects.push_back(CreateBoundingBoxDebugObject(ntt->GetBoundingBox(true)));
         }
 
         if (app->m_showDirectionalLightShadowFrustum)

--- a/Editor/EditorViewport.cpp
+++ b/Editor/EditorViewport.cpp
@@ -599,7 +599,7 @@ namespace ToolKit
               if (dwMesh->GetComponent<AABBOverrideComponent>() == nullptr)
               {
                 AABBOverrideComponentPtr aabbOverride = MakeNewPtr<AABBOverrideComponent>();
-                aabbOverride->SetAABB(dwMesh->GetAABB());
+                aabbOverride->SetBoundingBox(dwMesh->GetBoundingBox());
                 dwMesh->AddComponent(aabbOverride);
               }
             }
@@ -818,7 +818,7 @@ namespace ToolKit
         matComp->UpdateMaterialList();
 
         // Load bounding box once
-        *boundingBox = CreateBoundingBoxDebugObject((*dwMesh)->GetAABB(true));
+        *boundingBox = CreateBoundingBoxDebugObject((*dwMesh)->GetBoundingBox(true));
 
         // Add bounding box to the scene
         currScene->AddEntity(*boundingBox);
@@ -865,7 +865,7 @@ namespace ToolKit
       if (meshFound && boxMode)
       {
         float firstY       = lastDragMeshPos.y;
-        lastDragMeshPos.y -= dwMesh->GetAABB(false).min.y;
+        lastDragMeshPos.y -= dwMesh->GetBoundingBox(false).min.y;
 
         if (firstY > lastDragMeshPos.y)
         {

--- a/Editor/EntityView.cpp
+++ b/Editor/EntityView.cpp
@@ -176,7 +176,7 @@ namespace ToolKit
           ImGui::EndPopup();
         }
 
-        const Vec2 size = {canvasPanel->GetAABB(true).GetWidth(), canvasPanel->GetAABB(true).GetHeight()};
+        const Vec2 size = {canvasPanel->GetBoundingBox(true).GetWidth(), canvasPanel->GetBoundingBox(true).GetHeight()};
         float res[]     = {size.x, size.y};
         if (ImGui::InputFloat2("New resolution:", res))
         {
@@ -424,7 +424,7 @@ namespace ToolKit
 
         ImGui::Separator();
 
-        BoundingBox bb = ntt->GetAABB(true);
+        BoundingBox bb = ntt->GetBoundingBox(true);
         Vec3 dim       = bb.max - bb.min;
         ImGui::Text("Bounding box dimensions:");
         ImGui::Text("x: %.2f", dim.x);

--- a/Editor/Gizmo.cpp
+++ b/Editor/Gizmo.cpp
@@ -239,7 +239,7 @@ namespace ToolKit
       rayInObj.direction = its * Vec4(ray.direction, 0.0f);
 
       m_mesh->CalculateAABB();
-      return RayBoxIntersection(rayInObj, m_mesh->m_aabb, t);
+      return RayBoxIntersection(rayInObj, m_mesh->m_boundingBox, t);
     }
 
     Mat4 GizmoHandle::GetTransform() const
@@ -466,7 +466,7 @@ namespace ToolKit
       rayInObj.direction = its * Vec4(ray.direction, 0.0f);
 
       m_mesh->CalculateAABB();
-      return RayBoxIntersection(rayInObj, m_mesh->m_aabb, t);
+      return RayBoxIntersection(rayInObj, m_mesh->m_boundingBox, t);
     }
 
     // Gizmo

--- a/Editor/Grid.cpp
+++ b/Editor/Grid.cpp
@@ -193,7 +193,7 @@ namespace ToolKit
     bool Grid::HitTest(const Ray& ray, Vec3& pos)
     {
       float dist = 0.0f;
-      if (RayBoxIntersection(ray, GetAABB(true), dist))
+      if (RayBoxIntersection(ray, GetBoundingBox(true), dist))
       {
         pos = PointOnRay(ray, dist);
         return true;

--- a/Editor/MeshView.cpp
+++ b/Editor/MeshView.cpp
@@ -119,8 +119,8 @@ namespace ToolKit
       EntityPtrArray entities = m_viewport->GetScene()->GetEntities();
       for (EntityPtr ntt : entities)
       {
-        aabb.UpdateBoundary(ntt->GetAABB(true).min);
-        aabb.UpdateBoundary(ntt->GetAABB(true).max);
+        aabb.UpdateBoundary(ntt->GetBoundingBox(true).min);
+        aabb.UpdateBoundary(ntt->GetBoundingBox(true).max);
       }
 
       m_viewport->GetCamera()->FocusToBoundingBox(aabb, 1.0f);

--- a/Editor/Mod.cpp
+++ b/Editor/Mod.cpp
@@ -314,14 +314,14 @@ namespace ToolKit
           {
             g_app->m_cursor->m_worldLocation = pd.pickPos;
 
-            if (g_app->m_dbgArrow == nullptr)
+            if (g_app->m_dbgArrow != nullptr)
             {
               m_ignoreList.push_back(g_app->m_dbgArrow->GetIdVal());
               currScene->AddEntity(g_app->m_dbgArrow);
-            }
 
-            g_app->m_dbgArrow->m_node->SetTranslation(ray.position);
-            g_app->m_dbgArrow->m_node->SetOrientation(RotationTo(X_AXIS, ray.direction));
+              g_app->m_dbgArrow->m_node->SetTranslation(pd.pickPos + (ray.position - pd.pickPos) * 0.1f);
+              g_app->m_dbgArrow->m_node->SetOrientation(RotationTo(X_AXIS, ray.direction));
+            }
           }
 
           return StateType::StateEndPick;

--- a/Editor/Thumbnail.cpp
+++ b/Editor/Thumbnail.cpp
@@ -90,7 +90,7 @@ namespace ToolKit
         m_thumbnailScene->AddEntity(m_entity);
 
         m_cam->SetLens(glm::half_pi<float>(), 1.0f);
-        m_cam->FocusToBoundingBox(m_entity->GetAABB(true), 1.5f);
+        m_cam->FocusToBoundingBox(m_entity->GetBoundingBox(true), 1.5f);
       }
       else if (dirEnt.m_ext == MATERIAL)
       {

--- a/Editor/TransformMod.cpp
+++ b/Editor/TransformMod.cpp
@@ -637,7 +637,7 @@ namespace ToolKit
       scaleAxes[(int) AxisLabel::ZX]   = ZX_AXIS;
       scaleAxes[(int) AxisLabel::XYZ]  = Vec3(1.0f);
 
-      BoundingBox bb                   = ntt->GetAABB();
+      BoundingBox bb                   = ntt->GetBoundingBox();
       Vec3 aabbSize                    = bb.max - bb.min;
 
       int axisIndex                    = int(m_gizmo->GetGrabbedAxis());

--- a/Import/import.cpp
+++ b/Import/import.cpp
@@ -722,8 +722,8 @@ namespace ToolKit
     tMesh->m_material    = tMaterials[mesh->mMaterialIndex];
     for (ubyte i = 0; i < 3; i++)
     {
-      tMesh->m_aabb.min[i] = mesh->mAABB.mMin[i];
-      tMesh->m_aabb.max[i] = mesh->mAABB.mMax[i];
+      tMesh->m_boundingBox.min[i] = mesh->mAABB.mMin[i];
+      tMesh->m_boundingBox.max[i] = mesh->mAABB.mMax[i];
     }
   }
 

--- a/ToolKit/Canvas.cpp
+++ b/ToolKit/Canvas.cpp
@@ -106,7 +106,7 @@ namespace ToolKit
           // Scale operation
           {
             const Vec4 surfaceCurrentSize(surface->GetSizeVal(), 0.f, 1.f);
-            const BoundingBox surfaceBB       = surface->GetAABB(true);
+            const BoundingBox surfaceBB       = surface->GetBoundingBox(true);
 
             const float surfaceAbsoluteWidth  = surfaceBB.GetWidth();
             const float surfaceAbsoluteHeight = surfaceBB.GetHeight();
@@ -164,7 +164,7 @@ namespace ToolKit
           if (surface->IsA<Canvas>())
           {
             Canvas* canvasPanel  = static_cast<Canvas*>(surface);
-            const BoundingBox bb = canvasPanel->GetAABB(true);
+            const BoundingBox bb = canvasPanel->GetBoundingBox(true);
             canvasPanel->ApplyRecursiveResizePolicy(bb.GetWidth(), bb.GetHeight());
           }
         }

--- a/ToolKit/Entity.cpp
+++ b/ToolKit/Entity.cpp
@@ -96,19 +96,19 @@ namespace ToolKit
     anim->GetPose(m_node, time);
   }
 
-  BoundingBox Entity::GetAABB(bool inWorld) const
+  BoundingBox Entity::GetBoundingBox(bool inWorld) const
   {
     BoundingBox aabb;
     AABBOverrideComponent* overrideComp = GetComponentFast<AABBOverrideComponent>();
     if (overrideComp)
     {
-      aabb = overrideComp->GetAABB();
+      aabb = overrideComp->GetBoundingBox();
     }
     else
     {
       if (MeshComponent* meshComp = GetComponentFast<MeshComponent>())
       {
-        aabb = meshComp->GetAABB();
+        aabb = meshComp->GetBoundingBox();
       }
     }
 

--- a/ToolKit/Entity.cpp
+++ b/ToolKit/Entity.cpp
@@ -112,9 +112,14 @@ namespace ToolKit
       }
     }
 
-    if (inWorld)
+    if (!aabb.IsValid())
     {
-      TransformAABB(aabb, m_node->GetTransform(TransformationSpace::TS_WORLD));
+      // In case of an uninitialized bounding box, provide a very small box.
+      aabb = BoundingBox(Vec3(-TK_FLT_MIN), Vec3(TK_FLT_MIN));
+    }
+    else if (inWorld)
+    {
+      TransformAABB(aabb, m_node->GetTransform());
     }
 
     return aabb;

--- a/ToolKit/Entity.h
+++ b/ToolKit/Entity.h
@@ -42,7 +42,7 @@ namespace ToolKit
     EntityPtr Parent() const;
     virtual bool IsDrawable() const;
     virtual void SetPose(const AnimationPtr& anim, float time, BlendTarget* blendTarget = nullptr);
-    virtual BoundingBox GetAABB(bool inWorld = false) const;
+    virtual BoundingBox GetBoundingBox(bool inWorld = false) const;
     ObjectPtr Copy() const override;
     virtual void RemoveResources();
 

--- a/ToolKit/Light.cpp
+++ b/ToolKit/Light.cpp
@@ -107,11 +107,11 @@ namespace ToolKit
     m_shadowMapMaterial->Init();
   }
 
-  BoundingBox Light::GetAABB(bool inWorld) const
+  BoundingBox Light::GetBoundingBox(bool inWorld) const
   {
     if (m_volumeMesh != nullptr)
     {
-      BoundingBox lightVolume = m_volumeMesh->m_aabb;
+      BoundingBox lightVolume = m_volumeMesh->m_boundingBox;
       if (inWorld)
       {
         TransformAABB(lightVolume, m_node->GetTransform());
@@ -120,7 +120,7 @@ namespace ToolKit
       return lightVolume;
     }
 
-    return Super::GetAABB();
+    return Super::GetBoundingBox();
   }
 
   void Light::UpdateShadowCameraTransform()
@@ -289,7 +289,7 @@ namespace ToolKit
 
   PointLight::~PointLight() {}
 
-  BoundingBox PointLight::GetAABB(bool inWorld) const
+  BoundingBox PointLight::GetBoundingBox(bool inWorld) const
   {
     BoundingBox bb = m_boundingSphereCache.GetBoundingBox();
     if (!inWorld)

--- a/ToolKit/Light.h
+++ b/ToolKit/Light.h
@@ -45,9 +45,9 @@ namespace ToolKit
     virtual LightType GetLightType() = 0;
 
     /**
-     * Returns the bounding box of VolumeMesh of the light if its not null, otherwise calls Super::GetAABB().
+     * Returns the bounding box of VolumeMesh of the light if its not null, otherwise calls Super::GetBoundingBox().
      */
-    BoundingBox GetAABB(bool inWorld = false) const override;
+    BoundingBox GetBoundingBox(bool inWorld = false) const override;
 
    protected:
     void UpdateShadowCameraTransform();
@@ -122,7 +122,7 @@ namespace ToolKit
 
     LightType GetLightType() override { return LightType::Point; }
 
-    BoundingBox GetAABB(bool inWorld = false) const override;
+    BoundingBox GetBoundingBox(bool inWorld = false) const override;
 
     void UpdateShadowCamera() override;
     float AffectDistance() override;

--- a/ToolKit/MaterialComponent.cpp
+++ b/ToolKit/MaterialComponent.cpp
@@ -133,10 +133,10 @@ namespace ToolKit
     if (EntityPtr owner = OwnerEntity())
     {
       meshComp = owner->GetComponent<MeshComponent>();
-      if (meshComp == nullptr || meshComp->GetMeshVal() == nullptr)
+      if (meshComp != nullptr && meshComp->GetMeshVal() != nullptr)
       {
         MeshRawPtrArray meshCollector;
-        meshComp->GetMeshVal()->GetAllMeshes(meshCollector);
+        meshComp->GetMeshVal()->GetAllMeshes(meshCollector, true);
 
         for (uint i = 0; i < meshCollector.size(); i++)
         {

--- a/ToolKit/MathUtil.cpp
+++ b/ToolKit/MathUtil.cpp
@@ -764,7 +764,7 @@ namespace ToolKit
     Mat4 v          = camera->GetViewMatrix();
     Frustum frustum = ExtractFrustum(pr * v, false);
 
-    auto delFn      = [frustum](Entity* ntt) -> bool { return FrustumTest(frustum, ntt->GetAABB(true)); };
+    auto delFn      = [frustum](Entity* ntt) -> bool { return FrustumTest(frustum, ntt->GetBoundingBox(true)); };
     erase_if(entities, delFn);
   }
 

--- a/ToolKit/Mesh.cpp
+++ b/ToolKit/Mesh.cpp
@@ -223,7 +223,7 @@ namespace ToolKit
     }
 
     cpy->m_material = GetMaterialManager()->Copy<Material>(m_material);
-    cpy->m_aabb     = m_aabb;
+    cpy->m_boundingBox     = m_boundingBox;
 
     for (MeshPtr child : m_subMeshes)
     {
@@ -253,7 +253,7 @@ namespace ToolKit
         aabb.UpdateBoundary(v.pos);
       }
     }
-    m_aabb = aabb;
+    m_boundingBox = aabb;
   }
 
   void GetAllMeshHelper(const Mesh* mesh, MeshRawPtrArray& meshes)
@@ -445,7 +445,7 @@ namespace ToolKit
   template <typename T>
   void LoadMesh(XmlDocument* doc, XmlNode* parent, T* mainMesh)
   {
-    mainMesh->m_aabb = BoundingBox();
+    mainMesh->m_boundingBox = BoundingBox();
 
     T* mesh          = mainMesh;
     XmlNode* node    = parent;
@@ -504,7 +504,7 @@ namespace ToolKit
         {
           SkinVertex vd;
           ReadVec(v->first_node("p"), vd.pos);
-          mainMesh->m_aabb.UpdateBoundary(vd.pos);
+          mainMesh->m_boundingBox.UpdateBoundary(vd.pos);
 
           ReadVec(v->first_node("n"), vd.norm);
           ReadVec(v->first_node("t"), vd.tex);

--- a/ToolKit/Mesh.cpp
+++ b/ToolKit/Mesh.cpp
@@ -222,8 +222,8 @@ namespace ToolKit
       AddVRAMUsageInBytes(size);
     }
 
-    cpy->m_material = GetMaterialManager()->Copy<Material>(m_material);
-    cpy->m_boundingBox     = m_boundingBox;
+    cpy->m_material    = GetMaterialManager()->Copy<Material>(m_material);
+    cpy->m_boundingBox = m_boundingBox;
 
     for (MeshPtr child : m_subMeshes)
     {
@@ -447,8 +447,8 @@ namespace ToolKit
   {
     mainMesh->m_boundingBox = BoundingBox();
 
-    T* mesh          = mainMesh;
-    XmlNode* node    = parent;
+    T* mesh                 = mainMesh;
+    XmlNode* node           = parent;
 
     String typeString;
     if constexpr (std::is_same<T, Mesh>())
@@ -554,7 +554,7 @@ namespace ToolKit
     // This approach will flatten the mesh on a single sibling level.
     // To keep the depth hierarchy, recursive save is needed.
     MeshRawPtrArray cMeshes;
-    GetAllMeshes(cMeshes);
+    GetAllMeshes(cMeshes, true);
 
     for (const Mesh* m : cMeshes)
     {

--- a/ToolKit/Mesh.h
+++ b/ToolKit/Mesh.h
@@ -48,7 +48,7 @@ namespace ToolKit
     virtual bool IsSkinned() const;
 
     /**
-     * Calculates a bounding box for vertices in client side array for all meshes and submeshes. m_aabb becomes
+     * Calculates a bounding box for vertices in client side array for all meshes and submeshes. m_boundingBox becomes
      * valid after call to this.
      */
     void CalculateAABB();
@@ -101,7 +101,7 @@ namespace ToolKit
     uint m_indexCount  = 0;
     MaterialPtr m_material;
     MeshPtrArray m_subMeshes;
-    BoundingBox m_aabb;
+    BoundingBox m_boundingBox;
     FaceArray m_faces;
     VertexLayout m_vertexLayout;
 
@@ -135,7 +135,7 @@ namespace ToolKit
     bool IsSkinned() const override;
 
     // Because AABB is all dependent on active animation, just return AABB
-    // (doesn't change m_aabb)
+    // (doesn't change m_boundingBox)
     BoundingBox CalculateAABB(const Skeleton* skel, DynamicBoneMapPtr boneMap);
 
    protected:

--- a/ToolKit/MeshComponent.cpp
+++ b/ToolKit/MeshComponent.cpp
@@ -30,7 +30,7 @@ namespace ToolKit
     return mc;
   }
 
-  BoundingBox MeshComponent::GetAABB()
+  BoundingBox MeshComponent::GetBoundingBox()
   {
     SkeletonComponent* skelComp = OwnerEntity()->GetComponentFast<SkeletonComponent>();
     if (skelComp && GetMeshVal()->IsSkinned())
@@ -38,12 +38,12 @@ namespace ToolKit
       SkinMesh* skinMesh = (SkinMesh*) GetMeshVal().get();
       if (skelComp->isDirty)
       {
-        m_aabb            = skinMesh->CalculateAABB(skelComp->GetSkeletonResourceVal().get(), skelComp->m_map);
+        m_boundingBox            = skinMesh->CalculateAABB(skelComp->GetSkeletonResourceVal().get(), skelComp->m_map);
         skelComp->isDirty = false;
       }
-      return m_aabb;
+      return m_boundingBox;
     }
-    return GetMeshVal()->m_aabb;
+    return GetMeshVal()->m_boundingBox;
   }
 
   void MeshComponent::Init(bool flushClientSideArray) { GetMeshVal()->Init(flushClientSideArray); }

--- a/ToolKit/MeshComponent.h
+++ b/ToolKit/MeshComponent.h
@@ -46,7 +46,7 @@ namespace ToolKit
      * Gets the bounding box of the contained Mesh.
      * @return BoundingBox of the contained Mesh.
      */
-    BoundingBox GetAABB();
+    BoundingBox GetBoundingBox();
 
     /**
      * Initiates the MeshComponent and underlying Mesh and Material resources.
@@ -62,7 +62,7 @@ namespace ToolKit
     TKDeclareParam(bool, CastShadow);
 
    private:
-    BoundingBox m_aabb = {};
+    BoundingBox m_boundingBox = {};
   };
 
 } // namespace ToolKit

--- a/ToolKit/Pass.cpp
+++ b/ToolKit/Pass.cpp
@@ -207,11 +207,11 @@ namespace ToolKit
                       job.WorldTransform  = ntt->m_node->GetTransform();
                       if (AABBOverrideComponent* bbOverride = ntt->GetComponentFast<AABBOverrideComponent>())
                       {
-                        job.BoundingBox = std::move(bbOverride->GetAABB());
+                        job.BoundingBox = std::move(bbOverride->GetBoundingBox());
                       }
                       else
                       {
-                        job.BoundingBox = job.Mesh->m_aabb;
+                        job.BoundingBox = job.Mesh->m_boundingBox;
                       }
 
                       TransformAABB(job.BoundingBox, job.WorldTransform);

--- a/ToolKit/Prefab.cpp
+++ b/ToolKit/Prefab.cpp
@@ -79,7 +79,7 @@ namespace ToolKit
     return other;
   }
 
-  BoundingBox Prefab::GetAABB(bool inWorld) const
+  BoundingBox Prefab::GetBoundingBox(bool inWorld) const
   {
     BoundingBox boundingBox;
     if (m_prefabScene)

--- a/ToolKit/Prefab.cpp
+++ b/ToolKit/Prefab.cpp
@@ -8,6 +8,7 @@
 #include "Prefab.h"
 
 #include "Material.h"
+#include "MathUtil.h"
 #include "Scene.h"
 #include "ToolKit.h"
 
@@ -78,12 +79,28 @@ namespace ToolKit
     return other;
   }
 
+  BoundingBox Prefab::GetAABB(bool inWorld) const
+  {
+    BoundingBox boundingBox;
+    if (m_prefabScene)
+    {
+      boundingBox = m_prefabScene->m_boundingBox;
+      if (inWorld)
+      {
+        TransformAABB(boundingBox, m_node->GetTransform());
+      }
+    }
+
+    return boundingBox;
+  }
+
   void Prefab::Init(Scene* curScene)
   {
     if (m_initiated)
     {
       return;
     }
+
     m_currentScene    = curScene;
     String prefabPath = GetPrefabPathVal();
     prefabPath        = PrefabPath(prefabPath);

--- a/ToolKit/Prefab.h
+++ b/ToolKit/Prefab.h
@@ -50,7 +50,7 @@ namespace ToolKit
 
     static PrefabPtr GetPrefabRoot(const EntityPtr ntt);
     Entity* CopyTo(Entity* other) const override;
-    BoundingBox GetAABB(bool inWorld = false) const override;
+    BoundingBox GetBoundingBox(bool inWorld = false) const override;
 
    protected:
     XmlNode* SerializeImp(XmlDocument* doc, XmlNode* parent) const override;

--- a/ToolKit/Prefab.h
+++ b/ToolKit/Prefab.h
@@ -50,6 +50,7 @@ namespace ToolKit
 
     static PrefabPtr GetPrefabRoot(const EntityPtr ntt);
     Entity* CopyTo(Entity* other) const override;
+    BoundingBox GetAABB(bool inWorld = false) const override;
 
    protected:
     XmlNode* SerializeImp(XmlDocument* doc, XmlNode* parent) const override;

--- a/ToolKit/Primative.cpp
+++ b/ToolKit/Primative.cpp
@@ -817,7 +817,7 @@ namespace ToolKit
         Vec2(0.5f, 0.5f),        // tex coord
         Vec3(0.0f, 1.0f, 0.0f)   // btan
     };
-    mesh->m_aabb = BoundingBox(Vec3(-radius), Vec3(radius));
+    mesh->m_boundingBox = BoundingBox(Vec3(-radius), Vec3(radius));
 
     // create vertices
     for (int i = 0; i < numSegments; i++)

--- a/ToolKit/RHI.cpp
+++ b/ToolKit/RHI.cpp
@@ -13,8 +13,8 @@ namespace ToolKit
   GLuint RHI::m_currentReadFramebufferID = -1; // max unsigned integer
   GLuint RHI::m_currentDrawFramebufferID = -1; // max unsigned integer
   GLuint RHI::m_currentFramebufferID     = -1; // max unsigned integer
-
   GLuint RHI::m_currentVAO               = -1; // max unsigned integer
+  bool RHI::m_initialized                = false;
 
   std::unordered_map<uint, uint> RHI::m_slotTextureIDmap;
 
@@ -110,13 +110,16 @@ namespace ToolKit
 
   void RHI::DeleteTextures(int textureCount, GLuint* textures)
   {
-    for (int i = 0; i < 32; ++i)
+    if (m_initialized)
     {
-      for (int ii = 0; ii < textureCount; ++ii)
+      for (int i = 0; i < 32; ++i)
       {
-        if (m_slotTextureIDmap[i] == textures[ii])
+        for (int ii = 0; ii < textureCount; ++ii)
         {
-          m_slotTextureIDmap[i] = 0;
+          if (m_slotTextureIDmap[i] == textures[ii])
+          {
+            m_slotTextureIDmap[i] = 0;
+          }
         }
       }
     }

--- a/ToolKit/RHI.h
+++ b/ToolKit/RHI.h
@@ -19,6 +19,7 @@ namespace ToolKit
     friend class Framebuffer;
     friend class RenderSystem;
     friend class Mesh;
+    friend class Main;
 
    public:
     /**
@@ -27,7 +28,6 @@ namespace ToolKit
      */
     static void SetTexture(GLenum target, GLuint textureID, GLenum textureSlot = 31);
     static void DeleteTextures(int textureCount, GLuint* textures);
-
     static void BindVertexArray(GLuint VAO);
 
    private:
@@ -36,10 +36,10 @@ namespace ToolKit
     static void InvalidateFramebuffer(GLenum target, GLsizei numAttachments, const GLenum* attachments);
 
    private:
+    static bool m_initialized;
     static GLuint m_currentReadFramebufferID;
     static GLuint m_currentDrawFramebufferID;
     static GLuint m_currentFramebufferID;
-    
     static GLuint m_currentVAO;
 
     /**

--- a/ToolKit/ResourceComponent.cpp
+++ b/ToolKit/ResourceComponent.cpp
@@ -35,7 +35,7 @@ namespace ToolKit
 
   void AABBOverrideComponent::Init(bool flushClientSideArray) {}
 
-  BoundingBox AABBOverrideComponent::GetAABB()
+  BoundingBox AABBOverrideComponent::GetBoundingBox()
   {
     BoundingBox aabb = {};
     aabb.min         = GetPositionOffsetVal();
@@ -43,7 +43,7 @@ namespace ToolKit
     return aabb;
   }
 
-  void AABBOverrideComponent::SetAABB(BoundingBox aabb)
+  void AABBOverrideComponent::SetBoundingBox(BoundingBox aabb)
   {
     SetPositionOffsetVal(aabb.min);
     SetSizeVal(aabb.max - aabb.min);

--- a/ToolKit/ResourceComponent.h
+++ b/ToolKit/ResourceComponent.h
@@ -33,10 +33,10 @@ namespace ToolKit
     ComponentPtr Copy(EntityPtr ntt) override;
 
     void Init(bool flushClientSideArray);
-    BoundingBox GetAABB();
+    BoundingBox GetBoundingBox();
 
     // AABB should be in entity space (not world space)
-    void SetAABB(BoundingBox aabb);
+    void SetBoundingBox(BoundingBox aabb);
 
    protected:
     void ParameterConstructor() override;

--- a/ToolKit/Scene.cpp
+++ b/ToolKit/Scene.cpp
@@ -104,7 +104,7 @@ namespace ToolKit
           {
             AABBOverrideComponentPtr aabbOverride = MakeNewPtr<AABBOverrideComponent>();
             ntt->AddComponent(aabbOverride);
-            aabbOverride->SetAABB(ntt->GetAABB());
+            aabbOverride->SetBoundingBox(ntt->GetBoundingBox());
           }
         }
 
@@ -115,7 +115,7 @@ namespace ToolKit
         }
       }
 
-      BoundingBox worldBox = ntt->GetAABB(true);
+      BoundingBox worldBox = ntt->GetBoundingBox(true);
       m_boundingBox.UpdateBoundary(worldBox);
     }
 
@@ -138,7 +138,7 @@ namespace ToolKit
       EntityPtr& ntt        = m_entities[i];
 
       // update bounding box.
-      const BoundingBox& bb = ntt->GetAABB(true);
+      const BoundingBox& bb = ntt->GetBoundingBox(true);
       if (bb.IsValid())
       {
         m_boundingBox.UpdateBoundary(bb);
@@ -210,7 +210,7 @@ namespace ToolKit
         rayInObjectSpace.direction = its * Vec4(ray.direction, 0.0f);
 
         float dist                 = 0;
-        if (RayBoxIntersection(rayInObjectSpace, ntt->GetAABB(), dist))
+        if (RayBoxIntersection(rayInObjectSpace, ntt->GetBoundingBox(), dist))
         {
           bool hit         = false;
 
@@ -266,7 +266,7 @@ namespace ToolKit
           continue;
         }
 
-        BoundingBox bb      = ntt->GetAABB(true);
+        BoundingBox bb      = ntt->GetBoundingBox(true);
         IntersectResult res = FrustumBoxIntersection(frustum, bb);
         if (res != IntersectResult::Outside)
         {

--- a/ToolKit/Scene.cpp
+++ b/ToolKit/Scene.cpp
@@ -76,6 +76,7 @@ namespace ToolKit
       return;
     }
 
+    m_boundingBox                = BoundingBox();
     const EntityPtrArray& ntties = GetEntities();
     for (EntityPtr ntt : ntties)
     {
@@ -113,6 +114,9 @@ namespace ToolKit
           envCom->Init(true);
         }
       }
+
+      BoundingBox worldBox = ntt->GetAABB(true);
+      m_boundingBox.UpdateBoundary(worldBox);
     }
 
     m_initiated = true;
@@ -126,7 +130,7 @@ namespace ToolKit
     m_lightCache.clear();
     m_cameraCache.clear();
     m_environmentVolumeCache.clear();
-    m_skyCache = nullptr;
+    m_skyCache    = nullptr;
     m_boundingBox = BoundingBox();
 
     for (int i = 0; i < m_entities.size(); i++)

--- a/ToolKit/Scene.h
+++ b/ToolKit/Scene.h
@@ -315,8 +315,8 @@ namespace ToolKit
 
    public:
     /**
-     * A volume that covers all the entities in the scene.
-     * Its calculated during rendering. Its only valid after scene render.
+     * A world space volume that covers all the entities in the scene.
+     * Its calculated during rendering and Initialization. Its only valid after Init or scene render.
      */
     BoundingBox m_boundingBox;
 

--- a/ToolKit/Sky.cpp
+++ b/ToolKit/Sky.cpp
@@ -90,7 +90,7 @@ namespace ToolKit
     return hdri;
   }
 
-  BoundingBox SkyBase::GetAABB(bool inWorld) const
+  BoundingBox SkyBase::GetBoundingBox(bool inWorld) const
   {
     // Return a unit boundary.
     return {

--- a/ToolKit/Sky.h
+++ b/ToolKit/Sky.h
@@ -28,7 +28,7 @@ namespace ToolKit
     virtual MaterialPtr GetSkyboxMaterial();
     virtual CubeMapPtr GetIrradianceMap();
     HdriPtr GetHdri();
-    BoundingBox GetAABB(bool inWorld = false) const override;
+    BoundingBox GetBoundingBox(bool inWorld = false) const override;
 
    protected:
     void ParameterConstructor() override;

--- a/ToolKit/Surface.cpp
+++ b/ToolKit/Surface.cpp
@@ -335,7 +335,7 @@ namespace ToolKit
       return;
     }
 
-    const BoundingBox bb = canvasPanel->GetAABB(true);
+    const BoundingBox bb = canvasPanel->GetBoundingBox(true);
     const float w        = bb.GetWidth();
     const float h        = bb.GetHeight();
 
@@ -369,7 +369,7 @@ namespace ToolKit
     canvas[3]                   += axis[0] * ((1.f - m_anchorParams.m_anchorRatios[1]) * w);
     canvas[3].z                  = 0.f;
 
-    const BoundingBox surfaceBB  = GetAABB(true);
+    const BoundingBox surfaceBB  = GetBoundingBox(true);
     surface[0]                   = Vec3(surfaceBB.min.x, surfaceBB.max.y, 0.f);
     surface[1]                   = Vec3(surfaceBB.max.x, surfaceBB.max.y, 0.f);
     surface[2]                   = Vec3(surfaceBB.min.x, surfaceBB.min.y, 0.f);

--- a/ToolKit/ToolKit.cpp
+++ b/ToolKit/ToolKit.cpp
@@ -17,6 +17,7 @@
 #include "Object.h"
 #include "ObjectFactory.h"
 #include "PluginManager.h"
+#include "RHI.h"
 #include "RenderSystem.h"
 #include "Scene.h"
 #include "Shader.h"
@@ -133,6 +134,7 @@ namespace ToolKit
 
     m_logger->Log("Main Init");
 
+    RHI::m_initialized = true;
     m_pluginManager->Init();
     m_animationMan->Init();
     m_textureMan->Init();
@@ -153,6 +155,7 @@ namespace ToolKit
   {
     m_logger->Log("Main Uninit");
 
+    RHI::m_initialized = false;
     m_animationPlayer->m_records.clear();
     m_animationMan->Uninit();
     m_textureMan->Uninit();

--- a/ToolKit/UIManager.cpp
+++ b/ToolKit/UIManager.cpp
@@ -94,7 +94,7 @@ namespace ToolKit
     if (e->m_type == Event::EventType::Mouse || e->m_type == Event::EventType::Touch)
 
     {
-      BoundingBox box = surface->GetAABB(true);
+      BoundingBox box = surface->GetBoundingBox(true);
       Ray ray         = vp->RayFromMousePosition();
 
       float t         = 0.0f;


### PR DESCRIPTION
Fixes problems with null material list in material component,
wrong bounding box calc for prefab,
focusing to prefab fix,
exit crash due to RHI delete texture,
rename Get / Set AABB to  GetBoundingBox / SetBoundingBox,
Fix for rectangle selection assert.