### PR TITLE
BVH delete fix

### DIFF
--- a/Editor/Action.cpp
+++ b/Editor/Action.cpp
@@ -33,6 +33,9 @@ namespace ToolKit
       m_group.clear();
     }
 
+    // DeleteAction
+    //////////////////////////////////////////////////////////////////////////
+
     DeleteAction::DeleteAction(EntityPtr ntt)
     {
       m_parentId = NULL_HANDLE;
@@ -62,6 +65,8 @@ namespace ToolKit
     void DeleteAction::Undo()
     {
       assert(m_ntt != nullptr);
+
+      m_ntt->m_markedForDelete = false;
 
       EditorScenePtr currScene = g_app->GetCurrentScene();
       if (m_ntt->IsA<Prefab>())
@@ -95,13 +100,17 @@ namespace ToolKit
       }
 
       g_app->GetCurrentScene()->RemoveEntity(m_ntt->GetIdVal());
-      if (m_ntt->IsA<Prefab>())
+      if (Prefab* prefab = m_ntt->As<Prefab>())
       {
-        static_cast<Prefab*>(m_ntt.get())->Unlink();
+        prefab->Unlink();
       }
+
       m_actionComitted = true;
       HandleCompSpecificOps(m_ntt, m_actionComitted);
     }
+
+    // CreateAction
+    //////////////////////////////////////////////////////////////////////////
 
     CreateAction::CreateAction(EntityPtr ntt)
     {
@@ -153,6 +162,9 @@ namespace ToolKit
 
       Redo();
     }
+
+    // DeleteComponentAction
+    //////////////////////////////////////////////////////////////////////////
 
     void DeleteComponentAction::Undo()
     {

--- a/Editor/Action.h
+++ b/Editor/Action.h
@@ -15,6 +15,9 @@ namespace ToolKit
   namespace Editor
   {
 
+    // Action
+    //////////////////////////////////////////////////////////////////////////
+
     typedef std::vector<class Action*> ActionRawPtrArray;
 
     class Action
@@ -29,6 +32,9 @@ namespace ToolKit
      public:
       ActionRawPtrArray m_group;
     };
+
+    // DeleteAction
+    //////////////////////////////////////////////////////////////////////////
 
     class DeleteAction : public Action
     {
@@ -45,6 +51,9 @@ namespace ToolKit
       IDArray m_children;
       bool m_actionComitted;
     };
+
+    // CreateAction
+    //////////////////////////////////////////////////////////////////////////
 
     class CreateAction : public Action
     {
@@ -63,6 +72,9 @@ namespace ToolKit
       bool m_actionComitted;
       IDArray m_selecteds;
     };
+
+    // DeleteComponentAction
+    //////////////////////////////////////////////////////////////////////////
 
     class DeleteComponentAction : public Action
     {

--- a/Editor/AnchorMod.cpp
+++ b/Editor/AnchorMod.cpp
@@ -176,7 +176,7 @@ namespace ToolKit
         Vec3 camOrg         = vp->GetCamera()->m_node->GetTranslation(TransformationSpace::TS_WORLD);
         Vec3 anchorOrg      = m_anchor->m_worldLocation;
         Vec3 dir            = glm::normalize(camOrg - anchorOrg);
-        m_intersectionPlane = PlaneFrom(anchorOrg, Vec3 {0, 0, 1});
+        m_intersectionPlane = PlaneFrom(anchorOrg, Z_AXIS);
       }
     }
 

--- a/Editor/AnchorMod.cpp
+++ b/Editor/AnchorMod.cpp
@@ -188,7 +188,7 @@ namespace ToolKit
       {
         float t;
         Ray ray = vp->RayFromMousePosition();
-        if (LinePlaneIntersection(ray, m_intersectionPlane, t))
+        if (RayPlaneIntersection(ray, m_intersectionPlane, t))
         {
           m_anchor->m_grabPoint = PointOnRay(ray, t);
         }
@@ -319,11 +319,11 @@ namespace ToolKit
       {
         float t;
         Ray ray = vp->RayFromScreenSpacePoint(m_mouseData[1]);
-        if (LinePlaneIntersection(ray, m_intersectionPlane, t))
+        if (RayPlaneIntersection(ray, m_intersectionPlane, t))
         {
           Vec3 p = PointOnRay(ray, t);
           ray    = vp->RayFromScreenSpacePoint(m_mouseData[0]);
-          LinePlaneIntersection(ray, m_intersectionPlane, t);
+          RayPlaneIntersection(ray, m_intersectionPlane, t);
           Vec3 p0                = PointOnRay(ray, t);
           m_anchorDeltaTransform = p - p0;
         }

--- a/Editor/App.cpp
+++ b/Editor/App.cpp
@@ -211,10 +211,10 @@ namespace ToolKit
       // Render Viewports.
       for (EditorViewport* viewport : viewports)
       {
-        if (viewport->IsVisible())
-        {
-          viewport->Update(deltaTime);
+        viewport->Update(deltaTime);
 
+        if (viewport->IsShown())
+        {
           GetRenderSystem()->AddRenderTask({[this, viewport, deltaTime](Renderer* renderer) -> void
                                             {
                                               viewport->m_editorRenderer->m_params.UseMobileRenderPath =

--- a/Editor/EditorRenderer.cpp
+++ b/Editor/EditorRenderer.cpp
@@ -204,6 +204,19 @@ namespace ToolKit
         scene->m_bvh->GetDebugBVHBoxes(app->m_perFrameDebugObjects);
       }
 
+      if (app->m_showPickingDebug)
+      {
+        if (app->m_dbgArrow)
+        {
+          app->m_perFrameDebugObjects.push_back(app->m_dbgArrow);
+        }
+
+        if (app->m_dbgFrustum)
+        {
+          app->m_perFrameDebugObjects.push_back(app->m_dbgFrustum);
+        }
+      }
+
       // Generate Selection boundary and Environment component boundary.
       m_selecteds.clear();
       scene->GetSelectedEntities(m_selecteds);

--- a/Editor/FolderView.cpp
+++ b/Editor/FolderView.cpp
@@ -408,7 +408,7 @@ namespace ToolKit
               if (rm->m_baseType == Material::StaticClass())
               {
                 MaterialPtr mat                   = rm->Create<Material>(dirEnt.GetFullPath());
-                TempMaterialWindowPtr materialWnd = MakeNewPtr<TempMaterialWindow>();
+                MaterialWindowPtr materialWnd = MakeNewPtr<MaterialWindow>();
                 materialWnd->SetMaterial(mat);
                 materialWnd->AddToUI();
               }

--- a/Editor/MaterialView.cpp
+++ b/Editor/MaterialView.cpp
@@ -399,26 +399,26 @@ namespace ToolKit
       }
     }
 
-    // TempMaterialWindow
+    // MaterialWindow
     //////////////////////////////////////////////////////////////////////////
 
-    TKDefineClass(TempMaterialWindow, Window);
+    TKDefineClass(MaterialWindow, Window);
 
-    TempMaterialWindow::TempMaterialWindow()
+    MaterialWindow::MaterialWindow()
     {
       m_view               = MakeNewPtr<MaterialView>();
       m_view->m_isTempView = true;
     }
 
-    TempMaterialWindow::~TempMaterialWindow()
+    MaterialWindow::~MaterialWindow()
     {
       RemoveFromUI();
       m_view = nullptr;
     }
 
-    void TempMaterialWindow::SetMaterial(MaterialPtr mat) { m_view->SetMaterials({mat}); }
+    void MaterialWindow::SetMaterial(MaterialPtr mat) { m_view->SetMaterials({mat}); }
 
-    void TempMaterialWindow::Show()
+    void MaterialWindow::Show()
     {
       ImGuiIO io = ImGui::GetIO();
       ImGui::SetNextWindowSize(ImVec2(400, 700), ImGuiCond_Once);
@@ -426,11 +426,12 @@ namespace ToolKit
                               ImGuiCond_Once,
                               ImVec2(0.5f, 0.5f));
 
-      ImGui::Begin("Material View", &m_visible);
-
-      m_view->Show();
-
-      ImGui::End();
+      if (ImGui::Begin("Material View", &m_visible))
+      {
+        HandleStates();
+        m_view->Show();
+        ImGui::End();
+      }
     }
 
   } // namespace Editor

--- a/Editor/MaterialView.h
+++ b/Editor/MaterialView.h
@@ -46,16 +46,16 @@ namespace ToolKit
 
     typedef std::shared_ptr<MaterialView> MaterialViewPtr;
 
-    // TempMaterialWindow
+    // MaterialWindow
     //////////////////////////////////////////////////////////////////////////
 
-    class TempMaterialWindow : public Window
+    class MaterialWindow : public Window
     {
      public:
-      TKDeclareClass(TempMaterialWindow, Window);
+      TKDeclareClass(MaterialWindow, Window);
 
-      TempMaterialWindow();
-      ~TempMaterialWindow();
+      MaterialWindow();
+      ~MaterialWindow();
 
       void SetMaterial(MaterialPtr mat);
       void Show() override;
@@ -64,7 +64,7 @@ namespace ToolKit
       MaterialViewPtr m_view;
     };
 
-    typedef std::shared_ptr<TempMaterialWindow> TempMaterialWindowPtr;
+    typedef std::shared_ptr<MaterialWindow> MaterialWindowPtr;
 
   } // namespace Editor
 } // namespace ToolKit

--- a/Editor/Mod.cpp
+++ b/Editor/Mod.cpp
@@ -386,31 +386,24 @@ namespace ToolKit
           // Frustum from 8 points.
           Frustum frustum;
           Vec3Array planePnts;
-          Vec3Array centers;
 
           // Create plane equations such that normals point in to frustum.
-          planePnts = {rect3d[3], rect3d[7], rect3d[4]};                 // Left plane.
-          centers.push_back((rect3d[3] + rect3d[7] + rect3d[4]) / 3.0f); // Used to draw debug planes.
+          planePnts         = {rect3d[3], rect3d[7], rect3d[4]}; // Left plane.
           frustum.planes[0] = PlaneFrom(planePnts.data());
 
-          planePnts         = {rect3d[2], rect3d[5], rect3d[6]};         // Right plane.
-          centers.push_back((rect3d[2] + rect3d[5] + rect3d[6]) / 3.0f); // Used to draw debug planes.
+          planePnts         = {rect3d[2], rect3d[5], rect3d[6]}; // Right plane.
           frustum.planes[1] = PlaneFrom(planePnts.data());
 
-          planePnts         = {rect3d[1], rect3d[4], rect3d[5]};         // Top plane.
-          centers.push_back((rect3d[1] + rect3d[4] + rect3d[5]) / 3.0f); // Used to draw debug planes.
+          planePnts         = {rect3d[1], rect3d[4], rect3d[5]}; // Top plane.
           frustum.planes[2] = PlaneFrom(planePnts.data());
 
-          planePnts         = {rect3d[2], rect3d[6], rect3d[7]};         // Bottom plane.
-          centers.push_back((rect3d[2] + rect3d[6] + rect3d[7]) / 3.0f); // Used to draw debug planes.
+          planePnts         = {rect3d[2], rect3d[6], rect3d[7]}; // Bottom plane.
           frustum.planes[3] = PlaneFrom(planePnts.data());
 
-          planePnts         = {rect3d[3], rect3d[1], rect3d[2]};         // Near plane.
-          centers.push_back((rect3d[3] + rect3d[1] + rect3d[2]) / 3.0f); // Used to draw debug planes.
+          planePnts         = {rect3d[3], rect3d[1], rect3d[2]}; // Near plane.
           frustum.planes[4] = PlaneFrom(planePnts.data());
 
-          planePnts         = {rect3d[7], rect3d[6], rect3d[5]};         // Far plane.
-          centers.push_back((rect3d[7] + rect3d[6] + rect3d[5]) / 3.0f); // Used to draw debug planes.
+          planePnts         = {rect3d[7], rect3d[6], rect3d[5]}; // Far plane.
           frustum.planes[5] = PlaneFrom(planePnts.data());
 
           // Perform picking.
@@ -456,22 +449,6 @@ namespace ToolKit
             else
             {
               g_app->m_dbgFrustum->Generate(corners, X_AXIS, DrawType::Line);
-            }
-
-            // Generate frustum planes.
-            LineBatchPtr debFrust = g_app->m_dbgFrustum;
-            MeshPtr debFrustMesh  = debFrust->GetMeshComponent()->GetMeshVal();
-            for (int i = 0; i < 6; i++)
-            {
-              Vec3 pc               = frustum.planes[i].normal * frustum.planes[i].d;
-              Vec3 delta            = centers[i] - pc;
-              Mat4 move             = glm::translate(delta);
-
-              LineBatchPtr debPlane = CreatePlaneDebugObject(frustum.planes[i], 2.0f);
-              MeshPtr depPlaneMesh  = debPlane->GetMeshComponent()->GetMeshVal();
-              depPlaneMesh->ApplyTransform(move);
-
-              debFrustMesh->m_subMeshes.push_back(depPlaneMesh);
             }
           }
         }

--- a/Editor/Mod.cpp
+++ b/Editor/Mod.cpp
@@ -16,6 +16,7 @@
 #include <DirectionComponent.h>
 #include <Entity.h>
 #include <MathUtil.h>
+#include <Mesh.h>
 #include <Prefab.h>
 #include <Surface.h>
 
@@ -311,9 +312,6 @@ namespace ToolKit
 
             if (g_app->m_dbgArrow != nullptr)
             {
-              m_ignoreList.push_back(g_app->m_dbgArrow->GetIdVal());
-              currScene->AddEntity(g_app->m_dbgArrow);
-
               g_app->m_dbgArrow->m_node->SetTranslation(pd.pickPos + (ray.position - pd.pickPos) * 0.1f);
               g_app->m_dbgArrow->m_node->SetOrientation(RotationTo(X_AXIS, ray.direction));
             }
@@ -347,6 +345,7 @@ namespace ToolKit
         {
           CameraPtr cam = vp->GetCamera();
 
+          // Constructs mouse rectangle from lower left CCW.
           Vec2 rect[4];
           GetMouseRect(rect[0], rect[2]);
 
@@ -356,13 +355,14 @@ namespace ToolKit
           rect[3].y = rect[2].y;
 
           std::vector<Ray> rays;
-          std::vector<Vec3> rect3d;
+          Vec3Array rect3d;
 
-          // Front rectangle.
+          // Front rectangle in world space. From Upper left corner CW
+          // Conversion from lower left ccw to upper left cw happens during screen to viewport conversion.
           Vec3 lensLoc = cam->m_node->GetTranslation(TransformationSpace::TS_WORLD);
           for (int i = 0; i < 4; i++)
           {
-            Vec2 p  = vp->TransformScreenToViewportSpace(rect[i]);
+            Vec2 p  = vp->TransformScreenToViewportSpace(rect[i]); // ccw to cw.
             Vec3 p0 = vp->TransformViewportToWorldSpace(p);
             rect3d.push_back(p0);
             if (cam->IsOrtographic())
@@ -375,7 +375,7 @@ namespace ToolKit
             }
           }
 
-          // Back rectangle.
+          // Back rectangle in world space.
           float depth = 1000.0f;
           for (int i = 0; i < 4; i++)
           {
@@ -385,23 +385,32 @@ namespace ToolKit
 
           // Frustum from 8 points.
           Frustum frustum;
-          std::vector<Vec3> planePnts;
-          planePnts         = {rect3d[0], rect3d[7], rect3d[4]}; // Left plane.
+          Vec3Array planePnts;
+          Vec3Array centers;
+
+          // Create plane equations such that normals point in to frustum.
+          planePnts = {rect3d[3], rect3d[7], rect3d[4]};                 // Left plane.
+          centers.push_back((rect3d[3] + rect3d[7] + rect3d[4]) / 3.0f); // Used to draw debug planes.
           frustum.planes[0] = PlaneFrom(planePnts.data());
 
-          planePnts         = {rect3d[5], rect3d[6], rect3d[1]}; // Right plane.
+          planePnts         = {rect3d[2], rect3d[5], rect3d[6]};         // Right plane.
+          centers.push_back((rect3d[2] + rect3d[5] + rect3d[6]) / 3.0f); // Used to draw debug planes.
           frustum.planes[1] = PlaneFrom(planePnts.data());
 
-          planePnts         = {rect3d[4], rect3d[5], rect3d[0]}; // Top plane.
+          planePnts         = {rect3d[1], rect3d[4], rect3d[5]};         // Top plane.
+          centers.push_back((rect3d[1] + rect3d[4] + rect3d[5]) / 3.0f); // Used to draw debug planes.
           frustum.planes[2] = PlaneFrom(planePnts.data());
 
-          planePnts         = {rect3d[3], rect3d[6], rect3d[7]}; // Bottom plane.
+          planePnts         = {rect3d[2], rect3d[6], rect3d[7]};         // Bottom plane.
+          centers.push_back((rect3d[2] + rect3d[6] + rect3d[7]) / 3.0f); // Used to draw debug planes.
           frustum.planes[3] = PlaneFrom(planePnts.data());
 
-          planePnts         = {rect3d[0], rect3d[1], rect3d[3]}; // Near plane.
+          planePnts         = {rect3d[3], rect3d[1], rect3d[2]};         // Near plane.
+          centers.push_back((rect3d[3] + rect3d[1] + rect3d[2]) / 3.0f); // Used to draw debug planes.
           frustum.planes[4] = PlaneFrom(planePnts.data());
 
-          planePnts         = {rect3d[7], rect3d[5], rect3d[4]}; // Far plane.
+          planePnts         = {rect3d[7], rect3d[6], rect3d[5]};         // Far plane.
+          centers.push_back((rect3d[7] + rect3d[6] + rect3d[5]) / 3.0f); // Used to draw debug planes.
           frustum.planes[5] = PlaneFrom(planePnts.data());
 
           // Perform picking.
@@ -413,41 +422,56 @@ namespace ToolKit
           // Debug draw the picking frustum.
           if (g_app->m_showPickingDebug)
           {
-            std::vector<Vec3> corners = {rect3d[0],
-                                         rect3d[1],
-                                         rect3d[1],
-                                         rect3d[2],
-                                         rect3d[2],
-                                         rect3d[3],
-                                         rect3d[3],
-                                         rect3d[0],
-                                         rect3d[0],
-                                         rect3d[0] + rays[0].direction * depth,
-                                         rect3d[1],
-                                         rect3d[1] + rays[1].direction * depth,
-                                         rect3d[2],
-                                         rect3d[2] + rays[2].direction * depth,
-                                         rect3d[3],
-                                         rect3d[3] + rays[3].direction * depth,
-                                         rect3d[0] + rays[0].direction * depth,
-                                         rect3d[1] + rays[1].direction * depth,
-                                         rect3d[1] + rays[1].direction * depth,
-                                         rect3d[2] + rays[2].direction * depth,
-                                         rect3d[2] + rays[2].direction * depth,
-                                         rect3d[3] + rays[3].direction * depth,
-                                         rect3d[3] + rays[3].direction * depth,
-                                         rect3d[0] + rays[0].direction * depth};
+            Vec3Array corners = {rect3d[0],
+                                 rect3d[1],
+                                 rect3d[1],
+                                 rect3d[2],
+                                 rect3d[2],
+                                 rect3d[3],
+                                 rect3d[3],
+                                 rect3d[0],
+                                 rect3d[0],
+                                 rect3d[0] + rays[0].direction * depth,
+                                 rect3d[1],
+                                 rect3d[1] + rays[1].direction * depth,
+                                 rect3d[2],
+                                 rect3d[2] + rays[2].direction * depth,
+                                 rect3d[3],
+                                 rect3d[3] + rays[3].direction * depth,
+                                 rect3d[0] + rays[0].direction * depth,
+                                 rect3d[1] + rays[1].direction * depth,
+                                 rect3d[1] + rays[1].direction * depth,
+                                 rect3d[2] + rays[2].direction * depth,
+                                 rect3d[2] + rays[2].direction * depth,
+                                 rect3d[3] + rays[3].direction * depth,
+                                 rect3d[3] + rays[3].direction * depth,
+                                 rect3d[0] + rays[0].direction * depth};
 
+            // Generate debug frustum.
             if (g_app->m_dbgFrustum == nullptr)
             {
               g_app->m_dbgFrustum = MakeNewPtr<LineBatch>();
               g_app->m_dbgFrustum->Generate(corners, X_AXIS, DrawType::Line);
-              m_ignoreList.push_back(g_app->m_dbgFrustum->GetIdVal());
-              currScene->AddEntity(g_app->m_dbgFrustum);
             }
             else
             {
               g_app->m_dbgFrustum->Generate(corners, X_AXIS, DrawType::Line);
+            }
+
+            // Generate frustum planes.
+            LineBatchPtr debFrust = g_app->m_dbgFrustum;
+            MeshPtr debFrustMesh  = debFrust->GetMeshComponent()->GetMeshVal();
+            for (int i = 0; i < 6; i++)
+            {
+              Vec3 pc               = frustum.planes[i].normal * frustum.planes[i].d;
+              Vec3 delta            = centers[i] - pc;
+              Mat4 move             = glm::translate(delta);
+
+              LineBatchPtr debPlane = CreatePlaneDebugObject(frustum.planes[i], 2.0f);
+              MeshPtr depPlaneMesh  = debPlane->GetMeshComponent()->GetMeshVal();
+              depPlaneMesh->ApplyTransform(move);
+
+              debFrustMesh->m_subMeshes.push_back(depPlaneMesh);
             }
           }
         }

--- a/Editor/Mod.cpp
+++ b/Editor/Mod.cpp
@@ -503,10 +503,8 @@ namespace ToolKit
     {
       WindowPtr activeWnd = g_app->GetActiveWindow();
 
-      // Delete in the text edit, deletes the entities.
-      // Make sure delete is pressed only the given windows.
-      // TODO: Add Window a function that returns true if editing text. Window::IsEditingText()
-      if (!activeWnd->IsA<EditorViewport>() && !activeWnd->IsA<OutlinerWindow>())
+      // Prevent delete key during the text edit from deleting entities.
+      if (UI::IsKeyboardCaptured())
       {
         return NullSignal;
       }

--- a/Editor/RenderSettingsWindow.cpp
+++ b/Editor/RenderSettingsWindow.cpp
@@ -186,7 +186,6 @@ namespace ToolKit
             if (isSelected)
             {
               engineSettings.Graphics.cascadeCount = itemIndx + 1;
-              GetRenderSystem()->InvalidateShadowAtlas();
               GetRenderSystem()->InvalidateGPULightCache();
             }
           }

--- a/Editor/RenderSettingsWindow.cpp
+++ b/Editor/RenderSettingsWindow.cpp
@@ -175,6 +175,7 @@ namespace ToolKit
         const char* itemNames[] = {"1", "2", "3", "4"};
         const int itemCount     = sizeof(itemNames) / sizeof(itemNames[0]);
         int currentItem         = engineSettings.Graphics.cascadeCount - 1;
+
         if (ImGui::BeginCombo("Cascade Count", itemNames[currentItem]))
         {
           for (int itemIndx = 0; itemIndx < itemCount; itemIndx++)
@@ -193,12 +194,55 @@ namespace ToolKit
           ImGui::EndCombo();
         }
 
-        Vec4 data = {engineSettings.Graphics.cascadeDistances[1],
-                     engineSettings.Graphics.cascadeDistances[2],
-                     engineSettings.Graphics.cascadeDistances[3],
-                     engineSettings.PostProcessing.ShadowDistance};
-        if (ImGui::DragFloat4("CascadeDistances", &data[0]))
+        Vec4 data            = {engineSettings.Graphics.cascadeDistances[1],
+                                engineSettings.Graphics.cascadeDistances[2],
+                                engineSettings.Graphics.cascadeDistances[3],
+                                engineSettings.PostProcessing.ShadowDistance};
+
+        int lastCascadeIndex = engineSettings.Graphics.cascadeCount - 1;
+        Swap(data[lastCascadeIndex], data[3]);
+
+        Vec2 contentSize        = ImGui::GetContentRegionAvail();
+        float width             = contentSize.x * 0.95f / 4.0f;
+        width                   = glm::clamp(width, 10.0f, 100.0f);
+
+        bool cascadeInvalidated = false;
+        for (int i = 0; i < 4; i++)
         {
+          float val = data[i];
+          if (i > lastCascadeIndex)
+          {
+            ImGui::BeginDisabled();
+            val = 0.0f;
+          }
+
+          ImGui::PushID(i);
+          ImGui::PushItemWidth(width);
+
+          if (ImGui::DragFloat("##cascade", &val))
+          {
+            cascadeInvalidated = true;
+            data[i]            = val;
+          }
+
+          ImGui::PopItemWidth();
+          ImGui::PopID();
+
+          if (i > lastCascadeIndex)
+          {
+            ImGui::EndDisabled();
+          }
+
+          if (i < 3)
+          {
+            ImGui::SameLine();
+          }
+        }
+
+        if (cascadeInvalidated)
+        {
+          Swap(data[lastCascadeIndex], data[3]);
+
           GetRenderSystem()->InvalidateGPULightCache();
           engineSettings.Graphics.cascadeDistances[1]  = data.x;
           engineSettings.Graphics.cascadeDistances[2]  = data.y;
@@ -224,9 +268,9 @@ namespace ToolKit
             }
           }
         }
-
-      } // Imgui::Begin
+      }
       ImGui::End();
     }
+
   } // namespace Editor
 } // namespace ToolKit

--- a/Editor/TransformMod.cpp
+++ b/Editor/TransformMod.cpp
@@ -259,7 +259,7 @@ namespace ToolKit
             float t;
             PlaneEquation axisPlane = PlaneFrom(p, axis);
             Ray ray                 = vp->RayFromMousePosition();
-            if (LinePlaneIntersection(ray, axisPlane, t))
+            if (RayPlaneIntersection(ray, axisPlane, t))
             {
               Vec3 intersectPnt   = PointOnRay(ray, t);
               intersectPnt        = glm::normalize(intersectPnt - p);
@@ -329,7 +329,7 @@ namespace ToolKit
       {
         float t;
         Ray ray = vp->RayFromMousePosition();
-        if (LinePlaneIntersection(ray, m_intersectionPlane, t))
+        if (RayPlaneIntersection(ray, m_intersectionPlane, t))
         {
           m_gizmo->m_grabPoint = PointOnRay(ray, t);
         }
@@ -462,14 +462,14 @@ namespace ToolKit
       if (EditorViewportPtr vp = g_app->GetActiveViewport())
       {
         Ray ray = vp->RayFromScreenSpacePoint(m_mouseData[1]);
-        if (LinePlaneIntersection(ray, m_intersectionPlane, t))
+        if (RayPlaneIntersection(ray, m_intersectionPlane, t))
         {
           // This point.
           Vec3 p = PointOnRay(ray, t);
 
           // Previous. point.
           ray    = vp->RayFromScreenSpacePoint(m_mouseData[0]);
-          LinePlaneIntersection(ray, m_intersectionPlane, t);
+          RayPlaneIntersection(ray, m_intersectionPlane, t);
           Vec3 p0 = PointOnRay(ray, t);
           m_delta = p - p0;
         }

--- a/Editor/UI.cpp
+++ b/Editor/UI.cpp
@@ -477,6 +477,7 @@ namespace ToolKit
       }
 
       // Show volatile windows.
+      WindowPtrArray closedWindows;
       for (WindowPtr wnd : m_volatileWindows)
       {
         wnd->ResetState();
@@ -485,7 +486,17 @@ namespace ToolKit
         {
           wnd->Show();
         }
+        else
+        {
+          closedWindows.push_back(wnd);
+        }
       }
+
+      for (WindowPtr wnd : closedWindows)
+      {
+        wnd->RemoveFromUI();
+      }
+      closedWindows.clear();
 
       if (g_app->m_simulationViewport->IsVisible())
       {

--- a/Editor/UI.cpp
+++ b/Editor/UI.cpp
@@ -353,10 +353,7 @@ namespace ToolKit
       style.GrabRounding = style.FrameRounding = 2.3f;
     }
 
-    static __forceinline ImVec4 Inverse(const ImVec4& input)
-    {
-      return ImVec4(1.0f - input.x, 1.0f - input.y, 1.0f - input.z, 1.0f);
-    }
+    ImVec4 Inverse(const ImVec4& input) { return ImVec4(1.0f - input.x, 1.0f - input.y, 1.0f - input.z, 1.0f); }
 
     void LightTheme()
     {
@@ -471,6 +468,8 @@ namespace ToolKit
       // Show persistent windows.
       for (WindowPtr wnd : g_app->m_windows)
       {
+        wnd->ResetState();
+
         if (wnd->IsVisible())
         {
           wnd->Show();
@@ -480,6 +479,8 @@ namespace ToolKit
       // Show volatile windows.
       for (WindowPtr wnd : m_volatileWindows)
       {
+        wnd->ResetState();
+
         if (wnd->IsVisible())
         {
           wnd->Show();

--- a/Editor/Window.h
+++ b/Editor/Window.h
@@ -26,16 +26,45 @@ namespace ToolKit
       Window();
       virtual ~Window();
       virtual void Show() = 0;
-      void SetVisibility(bool visible);
 
       // Window queries.
-      bool IsActive() const;
-      bool IsVisible() const;
-      bool IsMoving() const;
-      bool MouseHovers() const;
-      bool CanDispatchSignals() const; // If active & visible & mouse hovers.
 
-      // System calls.
+      /**
+       * States if the window is visible and showing its content. That is, the window is not minimized or in an
+       * inactive tab.
+       */
+      bool IsShown();
+
+      /** States if the window is active window. A window is considered active if it has input focus. */
+      bool IsActive() const;
+
+      /**
+       * States if the window is visible, it can be tabbed or minimized.
+       * If you want to check if its rendering content, use IsShown().
+       */
+      bool IsVisible() const;
+
+      /** States if the window is moving or not. */
+      bool IsMoving() const;
+
+      /** States if the mouse is over the window or not. */
+      bool MouseHovers() const;
+
+      // Window functions.
+
+      /**
+       * Set window as visible, if its not visible it won't be shown. However, it may not be shown due to being an
+       * inactive tab or minimized window. Use IsShown to detect if the window is being shown or not.
+       */
+      void SetVisibility(bool visible);
+
+      /**
+       * States if a window can dispatch signals or not.
+       * If window is active & visible & mouse hovers on it, it can dispatch signals.
+       */
+      bool CanDispatchSignals() const;
+
+      /** Dispatch signals such as short cuts or system events. Mode manager captures and process signals. */
       virtual void DispatchSignals() const;
 
       /**
@@ -50,35 +79,48 @@ namespace ToolKit
        */
       void RemoveFromUI();
 
+      /** Internally used to reset per frame state such as m_isShown. */
+      void ResetState();
+
      protected:
       // Internal window handling.
       void HandleStates();
       void SetActive();
+      void TryActivateWindow(); //!< Internally used by HandleStates to try activating window with any mouse click.
       void ModShortCutSignals(const IntArray& mask = {}) const;
       XmlNode* SerializeImp(XmlDocument* doc, XmlNode* parent) const override;
       XmlNode* DeSerializeImp(const SerializationFileInfo& info, XmlNode* parent) override;
 
      protected:
       // States.
+
+      /** States if the window is visible, doesn't mean that its being shown. May be in a tab and hidden. */
       bool m_visible    = true;
+
+      /** States if the visible window is shown, not in a hidden tab or minimized. */
+      bool m_isShown    = false;
+
+      /** States if the input focus is on this window. */
       bool m_active     = false;
+
+      /** States if the mouse is over this window. */
       bool m_mouseHover = false;
-      bool m_moving     = false; //!< States if window is moving.
+
+      /** States if the user is dragging the window. */
+      bool m_moving     = false;
 
      public:
-      String m_name;
-      uint m_id;
-      UVec2 m_size;
-      IVec2 m_location;
+      String m_name;    //!< Name of the window.
+      uint m_id;        //!< Unique window id for the current runtime.
+      UVec2 m_size;     //!< Total window size.
+      IVec2 m_location; //!< Screen space window location.
 
      private:
-      // Internal unique id generator.
-      static uint m_baseId;
+      static uint m_baseId; //!< Internal counter for unique ids in current runtime.
     };
 
     typedef std::shared_ptr<Window> WindowPtr;
     typedef std::vector<WindowPtr> WindowPtrArray;
-    typedef std::vector<Window*> WindowRawPtrArray;
 
   } // namespace Editor
 } // namespace ToolKit

--- a/Editor/Window.h
+++ b/Editor/Window.h
@@ -84,10 +84,22 @@ namespace ToolKit
 
      protected:
       // Internal window handling.
+
+      /**
+       *Handle internal states of the window.
+       * Should be called in between the Show::ImGui::Begin / End function.
+       */
       void HandleStates();
+
+      /** Set the window as active window. */
       void SetActive();
-      void TryActivateWindow(); //!< Internally used by HandleStates to try activating window with any mouse click.
+
+      /** Internally used by HandleStates to try activating window with any mouse click. */
+      void TryActivateWindow();
+
+      /** Global shortcuts handled in this function. Can be overridden for extending it with new short cuts. */
       void ModShortCutSignals(const IntArray& mask = {}) const;
+
       XmlNode* SerializeImp(XmlDocument* doc, XmlNode* parent) const override;
       XmlNode* DeSerializeImp(const SerializationFileInfo& info, XmlNode* parent) override;
 

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -275,7 +275,7 @@ namespace ToolKit
             objFactory->Register<StatsWindow>();
             objFactory->Register<StringInputWindow>();
             objFactory->Register<YesNoWindow>();
-            objFactory->Register<TempMaterialWindow>();
+            objFactory->Register<MaterialWindow>();
             objFactory->Register<AndroidBuildWindow>();
             objFactory->Register<PluginWindow>();
             objFactory->Register<PluginSettingsWindow>();

--- a/ToolKit/BVH.cpp
+++ b/ToolKit/BVH.cpp
@@ -202,7 +202,7 @@ namespace ToolKit
       float dist;
       if (RayBoxIntersection(ray, currentNode->m_aabb, dist))
       {
-        if (currentNode->Leaf())
+        if (currentNode->IsLeaf())
         {
           for (EntityPtr ntt : currentNode->m_entites)
           {
@@ -235,7 +235,6 @@ namespace ToolKit
   void BVH::PickObject(const Frustum& frustum,
                        Scene::PickDataArray& pickedObjects,
                        const IDArray& ignoreList,
-                       const EntityPtrArray& extraList,
                        bool pickPartiallyInside)
   {
     m_bvhTree->m_nextNodes.clear();
@@ -255,163 +254,36 @@ namespace ToolKit
       pickedObjects.push_back(pd);
     };
 
-    while (!m_bvhTree->m_nextNodes.empty())
+    EntityRawPtrArray pickedEntities;
+    FrustumTest(frustum, pickedEntities);
+
+    for (Entity* ntt : pickedEntities)
     {
-      BVHNode* currentNode = m_bvhTree->m_nextNodes.front();
-      m_bvhTree->m_nextNodes.pop_front();
-
-      // If the nodes parent already is inside of the frustum, no need to check intersection
-      if (currentNode->m_frustumTestResult == IntersectResult::Inside)
-      {
-        if (currentNode->Leaf())
-        {
-          for (EntityPtr ntt : currentNode->m_entites)
-          {
-            entityTestFn(ntt);
-          }
-        }
-        else
-        {
-          currentNode->m_left->m_frustumTestResult  = IntersectResult::Inside;
-          currentNode->m_right->m_frustumTestResult = IntersectResult::Inside;
-
-          m_bvhTree->m_nextNodes.push_back(currentNode->m_left);
-          m_bvhTree->m_nextNodes.push_back(currentNode->m_right);
-        }
-
-        currentNode->m_frustumTestResult = IntersectResult::Outside; // Reset for reuse later ?
-        continue;
-      }
-
-      IntersectResult res = FrustumBoxIntersection(frustum, currentNode->m_aabb);
-      if (res == IntersectResult::Inside)
-      {
-        // This node and all children nodes of this node do not need to check intersection again
-        currentNode->m_frustumTestResult = IntersectResult::Inside;
-        m_bvhTree->m_nextNodes.push_back(currentNode);
-      }
-      else if (res == IntersectResult::Intersect)
-      {
-        if (currentNode->Leaf())
-        {
-          for (EntityPtr ntt : currentNode->m_entites)
-          {
-            if (contains(ignoreList, ntt->GetIdVal()))
-            {
-              continue;
-            }
-
-            const BoundingBox box = ntt->GetBoundingBox(true);
-            IntersectResult res   = FrustumBoxIntersection(frustum, box);
-
-            if (res != IntersectResult::Outside)
-            {
-              Scene::PickData pd;
-              pd.pickPos = (box.max + box.min) * 0.5f;
-              pd.entity  = ntt;
-
-              if (res == IntersectResult::Inside)
-              {
-                pickedObjects.push_back(pd);
-              }
-              else if (pickPartiallyInside)
-              {
-                pickedObjects.push_back(pd);
-              }
-            }
-          }
-        }
-        else
-        {
-          m_bvhTree->m_nextNodes.push_front(currentNode->m_left);
-          m_bvhTree->m_nextNodes.push_front(currentNode->m_right);
-        }
-      }
+      entityTestFn(ntt->Self<Entity>());
     }
-  }
-
-  BoundingBox BVH::GetFrustumBoundary(const Frustum& frustum) const
-  {
-    BoundingBox resultBB;
-
-    m_bvhTree->m_nextNodes.clear();
-    m_bvhTree->m_nextNodes.push_front(m_bvhTree->m_root);
-    while (!m_bvhTree->m_nextNodes.empty())
-    {
-      BVHNode* currentNode = m_bvhTree->m_nextNodes.front();
-      m_bvhTree->m_nextNodes.pop_front();
-
-      bool insideFrustum = currentNode->m_insideFrustum;
-      IntersectResult res;
-      if (!insideFrustum)
-      {
-        res           = FrustumBoxIntersection(frustum, currentNode->m_aabb);
-        insideFrustum = res == IntersectResult::Inside;
-      }
-
-      // If the nodes parent already is inside of the frustum, no need to check intersection
-      if (insideFrustum)
-      {
-        if (currentNode->Leaf())
-        {
-          if (!currentNode->m_entites.empty())
-          {
-            resultBB.UpdateBoundary(currentNode->m_aabb);
-          }
-        }
-        else
-        {
-          currentNode->m_left->m_insideFrustum  = true;
-          currentNode->m_right->m_insideFrustum = true;
-          m_bvhTree->m_nextNodes.push_back(currentNode->m_left);
-          m_bvhTree->m_nextNodes.push_back(currentNode->m_right);
-        }
-      }
-      else if (res == IntersectResult::Intersect)
-      {
-        if (currentNode->Leaf())
-        {
-          if (!currentNode->m_entites.empty())
-          {
-            resultBB.UpdateBoundary(currentNode->m_aabb);
-          }
-        }
-        else
-        {
-          currentNode->m_left->m_insideFrustum  = false;
-          currentNode->m_right->m_insideFrustum = false;
-          m_bvhTree->m_nextNodes.push_front(currentNode->m_left);
-          m_bvhTree->m_nextNodes.push_front(currentNode->m_right);
-        }
-      }
-
-      currentNode->m_insideFrustum = false;
-    }
-
-    return resultBB;
   }
 
   void BVH::FrustumTest(const Frustum& frustum, EntityRawPtrArray& entities)
   {
     m_bvhTree->m_nextNodes.clear();
     m_bvhTree->m_nextNodes.push_front(m_bvhTree->m_root);
+
     while (!m_bvhTree->m_nextNodes.empty())
     {
       BVHNode* currentNode = m_bvhTree->m_nextNodes.front();
       m_bvhTree->m_nextNodes.pop_front();
 
-      bool insideFrustum = currentNode->m_insideFrustum;
-      IntersectResult res;
-      if (!insideFrustum)
+      if (currentNode->IsRoot() || currentNode->IsOutsideFrustum())
       {
-        res           = FrustumBoxIntersection(frustum, currentNode->m_aabb);
-        insideFrustum = res == IntersectResult::Inside;
+        // Outside is an inherited value coming from an intersecting parent.
+        // To get the exact result for the current node it needs to be tested.
+        currentNode->m_frustumTestResult = FrustumBoxIntersection(frustum, currentNode->m_aabb);
       }
 
       // If the nodes parent already is inside of the frustum, no need to check intersection
-      if (insideFrustum)
+      if (currentNode->IsInsideFrustum())
       {
-        if (currentNode->Leaf())
+        if (currentNode->IsLeaf())
         {
           for (EntityPtr& ntt : currentNode->m_entites)
           {
@@ -423,15 +295,14 @@ namespace ToolKit
         }
         else
         {
-          currentNode->m_left->m_insideFrustum  = true;
-          currentNode->m_right->m_insideFrustum = true;
+          currentNode->m_left->m_frustumTestResult = IntersectResult::Inside;
           m_bvhTree->m_nextNodes.push_back(currentNode->m_left);
           m_bvhTree->m_nextNodes.push_back(currentNode->m_right);
         }
       }
-      else if (res == IntersectResult::Intersect)
+      else if (currentNode->IsIntersectFrustum())
       {
-        if (currentNode->Leaf())
+        if (currentNode->IsLeaf())
         {
           for (EntityPtr& ntt : currentNode->m_entites)
           {
@@ -449,14 +320,12 @@ namespace ToolKit
         }
         else
         {
-          currentNode->m_left->m_insideFrustum  = false;
-          currentNode->m_right->m_insideFrustum = false;
+          currentNode->m_left->m_frustumTestResult  = IntersectResult::Outside;
+          currentNode->m_right->m_frustumTestResult = IntersectResult::Outside;
           m_bvhTree->m_nextNodes.push_front(currentNode->m_left);
           m_bvhTree->m_nextNodes.push_front(currentNode->m_right);
         }
       }
-
-      currentNode->m_insideFrustum = false;
     }
   }
 
@@ -469,7 +338,7 @@ namespace ToolKit
       BVHNode* bvhNode = nextNodes.front();
       nextNodes.pop();
 
-      if (!bvhNode->Leaf())
+      if (!bvhNode->IsLeaf())
       {
         nextNodes.push(bvhNode->m_left);
         nextNodes.push(bvhNode->m_right);
@@ -491,7 +360,7 @@ namespace ToolKit
       assert(ntt->m_bvhNodes.size() <= 1 || ntt->IsA<Light>());
       for (BVHNode* node : ntt->m_bvhNodes)
       {
-        assert(node->Leaf() && "Entities should not hold non-leaf bvh nodes");
+        assert(node->IsLeaf() && "Entities should not hold non-leaf bvh nodes");
       }
     }
   }
@@ -508,7 +377,7 @@ namespace ToolKit
       m_bvhTree->m_nextNodes.pop_front();
       if (currentNode != nullptr)
       {
-        if (currentNode->Leaf())
+        if (currentNode->IsLeaf())
         {
           assignedNtties += (int) currentNode->m_entites.size();
         }
@@ -627,7 +496,7 @@ namespace ToolKit
       BVHNode* node = nextNodes.front();
       nextNodes.pop();
 
-      if (node->m_waitingForDeletion)
+      if (node->m_markedForDelete)
       {
         continue;
       }
@@ -641,7 +510,7 @@ namespace ToolKit
         }
       }
 
-      if (!node->Leaf())
+      if (!node->IsLeaf())
       {
         // intermediate node
 
@@ -781,7 +650,7 @@ namespace ToolKit
 
     for (BVHNode* bvhNode : entity->m_bvhNodes)
     {
-      if (bvhNode->m_waitingForDeletion)
+      if (bvhNode->m_markedForDelete)
       {
         continue;
       }
@@ -851,7 +720,7 @@ namespace ToolKit
 
   void BVHTree::UpdateLeaf(BVHNode* node, bool removedFromThisNode)
   {
-    if (!node->Leaf())
+    if (!node->IsLeaf())
     {
       // Light removals can come here, no need to update the bvh nodes.
       return;
@@ -987,7 +856,7 @@ namespace ToolKit
         node->m_entites.clear();
 
         UpdateLeaf(left, false);
-        if (!right->m_waitingForDeletion)
+        if (!right->m_markedForDelete)
         {
           UpdateLeaf(right, false);
         }
@@ -1002,14 +871,14 @@ namespace ToolKit
       bool conjunct       = false;
       if (leftNode == node)
       {
-        if (rightNode->Leaf() && rightNode->m_entites.size() + entityCount <= m_maxEntityCountPerBVHNode)
+        if (rightNode->IsLeaf() && rightNode->m_entites.size() + entityCount <= m_maxEntityCountPerBVHNode)
         {
           conjunct = true;
         }
       }
       else // if (rightNode == node)
       {
-        if (leftNode->Leaf() && leftNode->m_entites.size() + entityCount <= m_maxEntityCountPerBVHNode)
+        if (leftNode->IsLeaf() && leftNode->m_entites.size() + entityCount <= m_maxEntityCountPerBVHNode)
         {
           conjunct = true;
         }
@@ -1030,8 +899,8 @@ namespace ToolKit
         // remove duplicate entities
         RemoveDuplicates(parentNode->m_entites);
 
-        rightNode->m_waitingForDeletion = true;
-        leftNode->m_waitingForDeletion  = true;
+        rightNode->m_markedForDelete = true;
+        leftNode->m_markedForDelete  = true;
         m_nodesToDelete.push_back(rightNode);
         m_nodesToDelete.push_back(leftNode);
 

--- a/ToolKit/BVH.h
+++ b/ToolKit/BVH.h
@@ -22,24 +22,37 @@ namespace ToolKit
 
     int depth         = 0;
 
+    /** Parent bvh node. */
     BVHNode* m_parent = nullptr;
+    /** Left bvh node. */
     BVHNode* m_left   = nullptr;
+    /** Right bvh node. */
     BVHNode* m_right  = nullptr;
-
+    /** Boundary of the node. */
     BoundingBox m_aabb;
-
+    /** All entities inside this node. */
     EntityPtrArray m_entites;
+    /** All lights intersecting with this node. */
     LightPtrArray m_lights;
-
-    bool m_waitingForDeletion = false; //<! Internal variable. True if this node is going to be deleted by conjunction.
+    /** Internal variable. True if this node is going to be deleted by conjunction. */
+    bool m_markedForDelete              = false;
+    /** Holds the last query results. Preserve its state until the next query. */
     IntersectResult m_frustumTestResult = IntersectResult::Outside;
 
-    /**
-     * It is guaranteed that if left node is there, there will be right node too
-     */
-    inline bool Leaf() const { return m_left == nullptr; }
+    /** Evaluates last frustum query results and returns true if IntersectionResult is Inside. */
+    bool IsInsideFrustum() const { return m_frustumTestResult == IntersectResult::Inside; }
 
-    bool m_insideFrustum = false;
+    /** Evaluates last frustum query results and returns true if IntersectionResult is Inside. */
+    bool IsIntersectFrustum() const { return m_frustumTestResult == IntersectResult::Intersect; }
+
+    /** Evaluates last frustum query results and returns true if IntersectionResult is Outside. */
+    bool IsOutsideFrustum() const { return m_frustumTestResult == IntersectResult::Outside; }
+
+    /** Checks if the node is a leaf node. It is guaranteed that if left node is there, there will be right node too. */
+    bool IsLeaf() const { return m_left == nullptr; }
+
+    /** Checks wheter the node is root or not. Its considered a root node if it has no parent. */
+    bool IsRoot() const { return m_parent == nullptr; }
   };
 
   class TK_API BVHTree
@@ -99,10 +112,7 @@ namespace ToolKit
     void PickObject(const Frustum& frustum,
                     Scene::PickDataArray& pickedObjects,
                     const IDArray& ignoreList,
-                    const EntityPtrArray& extraList,
                     bool pickPartiallyInside);
-
-    BoundingBox GetFrustumBoundary(const Frustum& frustum) const;
 
     /**
      * Test bvh with a frustum and assign test results to BVHNodes.

--- a/ToolKit/Camera.cpp
+++ b/ToolKit/Camera.cpp
@@ -11,8 +11,6 @@
 #include "Node.h"
 #include "Util.h"
 
-
-
 namespace ToolKit
 {
 
@@ -191,6 +189,8 @@ namespace ToolKit
   }
 
   Vec3 Camera::Direction() const { return GetComponentFast<DirectionComponent>()->GetDirection(); }
+
+  float Camera::FocalLength() const { return 1.0f / glm::tan(m_fov * 0.5f); }
 
   Entity* Camera::CopyTo(Entity* copyTo) const
   {

--- a/ToolKit/Camera.h
+++ b/ToolKit/Camera.h
@@ -96,6 +96,8 @@ namespace ToolKit
 
     Vec3 Direction() const;
 
+    float FocalLength() const;
+
    protected:
     Entity* CopyTo(Entity* copyTo) const override;
     void ParameterConstructor() override;

--- a/ToolKit/Entity.h
+++ b/ToolKit/Entity.h
@@ -139,9 +139,7 @@ namespace ToolKit
       return nullptr;
     }
 
-    /**
-     * Faster version of the get component, if raw pointer is applicable.
-     */
+    /** Faster version of the get component, if raw pointer is applicable. */
     template <typename T>
     T* GetComponentFast() const
     {
@@ -162,7 +160,8 @@ namespace ToolKit
      */
     ComponentPtr GetComponent(ClassMeta* Class) const;
 
-    void ClearComponents(); //!< Removes all components from the entity.
+    /** Removes all components from the entity. */
+    void ClearComponents();
 
     /**
      * Used to identify if this Entity is a prefab, and if so, returns the
@@ -172,7 +171,8 @@ namespace ToolKit
      */
     Entity* GetPrefabRoot() const;
 
-    virtual void InvalidateSpatialCaches(); //!< BVH & Bounding boxes are invalidated.
+    /** BVH & Bounding boxes are invalidated. */
+    virtual void InvalidateSpatialCaches();
 
    protected:
     virtual Entity* CopyTo(Entity* other) const;
@@ -192,9 +192,7 @@ namespace ToolKit
     TKDeclareParam(bool, Visible);
     TKDeclareParam(bool, TransformLock);
 
-    /**
-     * Node that holds the transform and parenting data for the Entity.
-     */
+    /** Node that holds the transform and parenting data for the Entity. */
     Node* m_node;
 
     /**
@@ -214,12 +212,17 @@ namespace ToolKit
     std::vector<BVHNode*> m_bvhNodes; //!< BVHNodes that the entity is assigned.
 
     /** Internally used to mark the entity as being processed by bvh traverse algorithms. */
-    bool m_isInBVHProcess = false;
+    bool m_isInBVHProcess  = false;
+
+    /** Used in bvh stating that the entity is removed from scene and should not be considered in queries. */
+    bool m_markedForDelete = false;
 
    protected:
     BoundingBox m_localBoundingBoxCache;
     BoundingBox m_worldBoundingBoxCache;
-    bool m_boundingBoxCacheInvalidated = true; //!< If true, bounding box caches are updated upon access.
+
+    /** If true, bounding box caches are updated upon access. */
+    bool m_boundingBoxCacheInvalidated = true;
 
    private:
     /**

--- a/ToolKit/GeometryTypes.h
+++ b/ToolKit/GeometryTypes.h
@@ -142,6 +142,7 @@ namespace ToolKit
 
   /**
    * A struct representing a frustum in 3D space.
+   * Expecting all plane normals to point inwards the frustum.
    */
   struct Frustum
   {

--- a/ToolKit/GeometryTypes.h
+++ b/ToolKit/GeometryTypes.h
@@ -132,11 +132,12 @@ namespace ToolKit
 
   /**
    * A struct representing a plane equation in 3D space.
+   * Plane equation: ax+by+cz+(-d)=0
    */
   struct PlaneEquation
   {
     Vec3 normal; //!< The normal vector of the plane.
-    float d;     //!< The distance from the origin to the plane along the normal.
+    float d;     //!< Negated distance to the plane from origin.
   };
 
   /**

--- a/ToolKit/MathUtil.cpp
+++ b/ToolKit/MathUtil.cpp
@@ -626,15 +626,6 @@ namespace ToolKit
     return ret;
   }
 
-  Quaternion QuaternionLookAt(Vec3 direction)
-  {
-    Mat3 Result {};
-    Result[2] = -glm::normalize(direction);
-    Result[0] = glm::normalize(glm::cross(Y_AXIS, Result[2]));
-    Result[1] = glm::cross(Result[2], Result[0]);
-    return glm::quat_cast(Result);
-  }
-
   // frustum should be normalized
   bool FrustumSphereIntersection(const Frustum& frustum, const Vec3& pos, float radius)
   {

--- a/ToolKit/MathUtil.cpp
+++ b/ToolKit/MathUtil.cpp
@@ -907,13 +907,13 @@ namespace ToolKit
 
   PlaneEquation PlaneFrom(const Vec3 pnts[3])
   {
-    // Expecting 3 non coplanar points in CCW order.
+    // Expecting 3 non collinear points in CCW order.
     Vec3 v1 = pnts[1] - pnts[0];
     Vec3 v2 = pnts[2] - pnts[0];
 
     PlaneEquation eq;
     eq.normal = glm::normalize(glm::cross(v1, v2));
-    eq.d      = -glm::dot(eq.normal, pnts[0]);
+    eq.d      = glm::dot(eq.normal, pnts[0]);
 
     return eq;
   }

--- a/ToolKit/MathUtil.cpp
+++ b/ToolKit/MathUtil.cpp
@@ -695,13 +695,12 @@ namespace ToolKit
 
   bool RayPlaneIntersection(const Ray& ray, const PlaneEquation& plane, float& t)
   {
-    float denom = glm::dot(ray.direction, plane.normal);
-    // Ray and plane facing(-). Not parallel (0) or ray facing plane's back (+).
-    if (glm::lessThan(denom, 0.0f))
+    float project = glm::dot(ray.direction, plane.normal);
+    if (glm::notEqual(project, 0.0f)) // Ray & Plane is not parallel.
     {
-      t = -(glm::dot(plane.normal, ray.position) - plane.d) / denom;
-      // On (0) or in front of (+) the plane.
-      return glm::greaterThanEqual(t, 0.0f);
+      // https://www.cs.princeton.edu/courses/archive/fall00/cs426/lectures/raycast/sld017.htm
+      t = -(glm::dot(plane.normal, ray.position) + plane.d) / project;
+      return true;
     }
 
     return false;
@@ -726,18 +725,6 @@ namespace ToolKit
 
     t = (-b - glm::sqrt((b * b) - 4.0f * a * c)) / (2.0f * a);
     return true;
-  }
-
-  bool LinePlaneIntersection(const Ray& ray, const PlaneEquation& plane, float& t)
-  {
-    float denom = glm::dot(ray.direction, plane.normal);
-    if (glm::notEqual(denom, 0.0f)) // Not parallel (0).
-    {
-      t = -(glm::dot(plane.normal, ray.position) - plane.d) / denom;
-      return true;
-    }
-
-    return false;
   }
 
   Vec3 PointOnRay(const Ray& ray, float t) { return ray.position + ray.direction * t; }

--- a/ToolKit/MathUtil.cpp
+++ b/ToolKit/MathUtil.cpp
@@ -19,8 +19,6 @@
 
 #include <random>
 
-
-
 namespace ToolKit
 {
 
@@ -175,7 +173,7 @@ namespace ToolKit
    * projection * view * model, then the algorithm gives the clipping planes in
    * model space
    */
-  // http://www.cs.otago.ac.nz/postgrads/alexis/planeExtraction.pdf
+  // https://www8.cs.umu.se/kurser/5DV051/HT12/lab/plane_extraction.pdf
   Frustum ExtractFrustum(const Mat4& projectViewModelMat, bool normalize)
   {
     Mat4 projectViewModel = glm::transpose(projectViewModelMat);
@@ -577,79 +575,55 @@ namespace ToolKit
     return closestIndx;
   }
 
-  /*
-   * When the plane equation is not normalized, the distance of a point to the
-   * plane: If distance < 0 , then the point p lies in the negative halfspace.
-   * If distance = 0 , then the point p lies in the plane.
-   * If distance > 0 , then the point p lies in the positive halfspace.
-   */
+  // Inequalities are reverted to work with frustum normals pointing inwards.
+  // Large objects picked falsely.
+  // https://gist.github.com/Kinwailo/d9a07f98d8511206182e50acda4fbc9b
   IntersectResult FrustumBoxIntersection(const Frustum& frustum, const BoundingBox& box)
   {
+    IntersectResult ret = IntersectResult::Inside;
     Vec3 vmin, vmax;
-    IntersectResult res = IntersectResult::Inside;
 
     for (int i = 0; i < 6; ++i)
     {
-      // X axis.
-      if (frustum.planes[i].normal.x > 0)
-      {
-        vmin.x = box.max.x;
-        vmax.x = box.min.x;
-      }
-      else
+      // X axis
+      if (frustum.planes[i].normal.x < 0)
       {
         vmin.x = box.min.x;
         vmax.x = box.max.x;
       }
-
-      // Y axis.
-      if (frustum.planes[i].normal.y > 0)
-      {
-        vmin.y = box.max.y;
-        vmax.y = box.min.y;
-      }
       else
+      {
+        vmin.x = box.max.x;
+        vmax.x = box.min.x;
+      }
+      // Y axis
+      if (frustum.planes[i].normal.y < 0)
       {
         vmin.y = box.min.y;
         vmax.y = box.max.y;
       }
-
-      // Z axis.
-      if (frustum.planes[i].normal.z > 0)
-      {
-        vmin.z = box.max.z;
-        vmax.z = box.min.z;
-      }
       else
+      {
+        vmin.y = box.max.y;
+        vmax.y = box.min.y;
+      }
+      // Z axis
+      if (frustum.planes[i].normal.z < 0)
       {
         vmin.z = box.min.z;
         vmax.z = box.max.z;
       }
-
-      float distmin = glm::dot(frustum.planes[i].normal, vmin) + frustum.planes[i].d;
-      if (distmin > 0)
-      {
-        float distmax = glm::dot(frustum.planes[i].normal, vmax) + frustum.planes[i].d;
-        if (distmax <= 0)
-        {
-          res = IntersectResult::Intersect;
-        }
-        else
-        {
-          // Inside
-        }
-      }
-      else if (distmin < 0)
-      {
-        return IntersectResult::Outside;
-      }
       else
       {
-        res = IntersectResult::Intersect;
+        vmin.z = box.max.z;
+        vmax.z = box.min.z;
       }
+      if (glm::dot(frustum.planes[i].normal, vmin) + frustum.planes[i].d < 0)
+        return IntersectResult::Outside;
+      if (glm::dot(frustum.planes[i].normal, vmax) + frustum.planes[i].d <= 0)
+        ret = IntersectResult::Intersect;
     }
-
-    return res;
+    return ret;
   }
 
   Quaternion QuaternionLookAt(Vec3 direction)
@@ -768,21 +742,16 @@ namespace ToolKit
 
   Vec3 PointOnRay(const Ray& ray, float t) { return ray.position + ray.direction * t; }
 
-  // https://forum.unity.com/threads/how-do-i-find-the-closest-point-on-a-line.340058/
-  TK_API Vec3 ProjectPointOntoLine(const Ray& baseLine, const Vec3& point)
-  {
-    Vec3 v  = point - baseLine.position;
-    float d = dot(v, baseLine.direction);
-    return baseLine.position + (baseLine.direction * d);
-  }
-
-  // http://www.cs.otago.ac.nz/postgrads/alexis/planeExtraction.pdf
+  // https://www8.cs.umu.se/kurser/5DV051/HT12/lab/plane_extraction.pdf
   void NormalizePlaneEquation(PlaneEquation& plane)
   {
     float mag      = glm::length(plane.normal);
     plane.normal.x = plane.normal.x / mag;
     plane.normal.y = plane.normal.y / mag;
     plane.normal.z = plane.normal.z / mag;
+
+    // This is needed because for any given point p equation must hold.
+    // That is ax+by+cz+(-d)=0 will hold after the d is also normalized.
     plane.d        = plane.d / mag;
   }
 
@@ -913,7 +882,7 @@ namespace ToolKit
 
     PlaneEquation eq;
     eq.normal = glm::normalize(glm::cross(v1, v2));
-    eq.d      = glm::dot(eq.normal, pnts[0]);
+    eq.d      = -glm::dot(eq.normal, pnts[0]);
 
     return eq;
   }
@@ -922,27 +891,8 @@ namespace ToolKit
   {
     assert(glm::isNormalized(normal, 0.0001f) && "Normalized vector expected.");
 
-    PlaneEquation plane = {normal, 0.0f};
-    plane.d             = glm::dot(point, normal) / glm::dot(normal, normal);
-
+    PlaneEquation plane = {normal, -glm::dot(point, normal)};
     return plane;
-  }
-
-  float SignedDistance(const PlaneEquation& plane, const Vec3& pnt)
-  {
-    assert(glm::isNormalized(plane.normal, 0.0001f) && "Normalized vector expected.");
-
-    Vec3 planeOrig = plane.normal * plane.d;
-    Vec3 checkPnt  = pnt - planeOrig;
-
-    return glm::dot(checkPnt, plane.normal);
-  }
-
-  Vec3 ProjectPointOntoPlane(const PlaneEquation& plane, const Vec3& pnt)
-  {
-    assert(glm::isNormalized(plane.normal, 0.0001f) && "Normalized vector expected.");
-
-    return pnt - glm::dot(plane.normal, pnt) * plane.normal;
   }
 
   Vec3 Interpolate(const Vec3& vec1, const Vec3& vec2, float ratio) { return (vec2 - vec1) * ratio + vec1; }
@@ -963,26 +913,27 @@ namespace ToolKit
 
   Quaternion RotationTo(Vec3 a, Vec3 b)
   {
-    a = glm::normalize(a);
-    b = glm::normalize(b);
+    a              = normalize(a);
+    b              = normalize(b);
 
-    Vec3 axis;
-    float d = glm::dot(a, b);
-    if (glm::equal<float>(d, 1.0f))
+    Vec3 axis      = normalize(cross(a, b));
+    float cosAngle = dot(a, b);
+
+    // Handle colinear vectors (including opposite directions)
+    if (abs(cosAngle) >= 1.0f - glm::epsilon<float>())
     {
-      return Quaternion(); // Vectors are colinear.
-    }
-    else if (glm::equal<float>(d, -1.0f)) // Vectors are oposite, align them.
-    {
-      axis = Orthogonal(a);
-    }
-    else
-    {
-      axis = glm::normalize(glm::cross(a, b));
+      // If very close to 1 or -1, choose an arbitrary perpendicular axis
+      axis = Orthogonal(a); // You can define orthogonal here if not available
     }
 
-    float rad = glm::acos(d);
-    return glm::angleAxis(rad, axis);
+    // Calculate shortest rotation angle considering opposite directions
+    float angle = acos(cosAngle);
+    if (dot(cross(a, b), b) < 0.0f)
+    {
+      angle = glm::pi<float>() - angle;
+    }
+
+    return angleAxis(angle, axis);
   }
 
   // Converted from OgreVector3.h perpendicular()

--- a/ToolKit/MathUtil.h
+++ b/ToolKit/MathUtil.h
@@ -110,19 +110,24 @@ namespace ToolKit
   // Geometric Operations
   //////////////////////////////////////////
 
-  TK_API void NormalizePlaneEquation(PlaneEquation& plane);
+  /** Transforms the 8 corners of the bounding box and recalculates new boundary from transformed points. */
   TK_API void TransformAABB(BoundingBox& box, const Mat4& transform);
-  TK_API void GetCorners(const BoundingBox& box, Vec3Array& corners);
-  TK_API PlaneEquation PlaneFrom(const Vec3 pnts[3]);
-  TK_API PlaneEquation PlaneFrom(Vec3 point, Vec3 normal);
-  TK_API float SignedDistance(const PlaneEquation& plane, const Vec3& pnt);
-  TK_API Vec3 ProjectPointOntoPlane(const PlaneEquation& plane, const Vec3& pt);
-  TK_API Vec3 ProjectPointOntoLine(const Ray& ray, const Vec3& pnt);
 
-  /**
-   * Returns True if box is outside of the frustum
-   */
+  /** Calculates 8 corners of the given bounding box. */
+  TK_API void GetCorners(const BoundingBox& box, Vec3Array& corners);
+
+  /** Normalize the plane equation by normalizing its normal and dividing normal's magnitude by the distance d. */
+  TK_API void NormalizePlaneEquation(PlaneEquation& plane);
+
+  /** Construct a plane equation in the form of ax+by+cz+(-d)=0 */
+  TK_API PlaneEquation PlaneFrom(const Vec3 pnts[3]);
+
+  /** Construct a plane equation in the form of ax+by+cz+(-d)=0 */
+  TK_API PlaneEquation PlaneFrom(Vec3 point, Vec3 normal);
+
+  /** Tests the box against the frustum and returns true if its intersects or inside. */
   TK_API bool FrustumTest(const Frustum& frustum, const BoundingBox& box);
+
   /**
    * Removes the entities that are outside of the camera.
    * @param entities All entities.
@@ -137,11 +142,17 @@ namespace ToolKit
   //////////////////////////////////////////
 
   TK_API Vec3 Interpolate(const Vec3& vec1, const Vec3& vec2, float ratio);
+
+  /** From the given point, calculates radius (r), angle from y axis (zenith), angle in xz plane (azimuth) */
   TK_API void ToSpherical(Vec3 p, float& r, float& zenith, float& azimuth);
+
+  /** From given spherical coordinates calculates a point in Cartesian space. */
   TK_API Vec3 ToCartesian(float r, float zenith, float azimuth);
-  // Returns quaternion wich rotates a on to b.
+
+  /** Returns quaternion wich rotates a on to b. */
   TK_API Quaternion RotationTo(Vec3 a, Vec3 b);
-  // Returns an orthogonal vector to v.
+
+  /** Returns an orthogonal vector to v. */
   TK_API Vec3 Orthogonal(const Vec3& v);
 
   // Comparison

--- a/ToolKit/MathUtil.h
+++ b/ToolKit/MathUtil.h
@@ -101,10 +101,6 @@ namespace ToolKit
 
   TK_API bool RaySphereIntersection(const Ray& ray, const BoundingSphere& sphere, float& t);
 
-  // Line is same as ray but it is infinite on both sides.
-  // Unless ray is parallel to plane, it will always yield a result.
-  TK_API bool LinePlaneIntersection(const Ray& ray, const PlaneEquation& plane, float& t);
-
   TK_API Vec3 PointOnRay(const Ray& ray, float t);
 
   // Geometric Operations

--- a/ToolKit/MathUtil.h
+++ b/ToolKit/MathUtil.h
@@ -13,7 +13,7 @@ namespace ToolKit
 {
 
   // Matrix Operations
-  //////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////
 
   TK_API void DecomposeMatrix(const Mat4& transform, Vec3* translation, Quaternion* orientation, Vec3* scale);
 
@@ -21,14 +21,30 @@ namespace ToolKit
 
   TK_API void QDUDecomposition(const Mat3& transform, Mat3& kQ, Vec3& kD, Vec3& kU);
 
+  /** Extracts the basis vectors from the transform matrix. */
   TK_API void ExtractAxes(const Mat4& transform, Vec3& x, Vec3& y, Vec3& z, bool normalize = true);
 
+  /*
+   * Extracts a frustum from given matrix whose plane normals are pointing inwards.
+   *
+   * If the given matrix is projection matrix, then the algorithm gives the
+   * clipping planes in view space If the matrix is projection * view,then the
+   * algorithm gives the clipping planes in world space If the matrix is
+   * projection * view * model, then the algorithm gives the clipping planes in
+   * model space
+   *
+   * @param projectViewModel is the matrix to extract frustum from.
+   * @param normalize if set true normalizes the frustum matrices.
+   *
+   * @return Frustum that is extracted from given matrix.
+   */
   TK_API Frustum ExtractFrustum(const Mat4& projectViewModel, bool normalize);
 
+  /** Normalizes frustum's planes. */
   TK_API void NormalizeFrustum(Frustum& frustum);
 
   // Intersections
-  //////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////
 
   enum class IntersectResult
   {
@@ -77,8 +93,7 @@ namespace ToolKit
   // Tracing possible object: Vertex positions should be in memory
   TK_API uint FindMeshIntersection(const EntityPtr ntt, const Ray& ray, float& t);
 
-  TK_API IntersectResult FrustumBoxIntersection(const Frustum& frustum,
-                                                const BoundingBox& box); // 0 outside, 1 inside, 2 intersect
+  TK_API IntersectResult FrustumBoxIntersection(const Frustum& frustum, const BoundingBox& box);
 
   TK_API bool ConePointIntersection(Vec3 conePos, Vec3 coneDir, float coneHeight, float coneAngle, Vec3 point);
 
@@ -88,20 +103,22 @@ namespace ToolKit
                                    float coneHeight,
                                    float coneAngle);
 
-  TK_API Quaternion QuaternionLookAt(Vec3 direction);
-
-  /**
-   * Tests normalized frustum with a sphere.
-   */
+  /** Tests normalized frustum with a sphere. */
   TK_API bool FrustumSphereIntersection(const Frustum& frustum, const Vec3& pos, float radius);
 
+  /** Tests normalized frustum with a sphere. */
   TK_API bool FrustumSphereIntersection(const Frustum& frustum, const BoundingSphere& sphere);
 
+  /** Tests a ray with a plane if there is an intersection sets the t as distance from ray to plane. */
   TK_API bool RayPlaneIntersection(const Ray& ray, const PlaneEquation& plane, float& t);
 
   TK_API bool RaySphereIntersection(const Ray& ray, const BoundingSphere& sphere, float& t);
 
+  /** Finds a point at t distance away from the ray. */
   TK_API Vec3 PointOnRay(const Ray& ray, float t);
+
+  /** Tests whether the given point is inside the given boundary. */
+  TK_API bool PointInsideBBox(const Vec3& point, const Vec3& max, const Vec3& min);
 
   // Geometric Operations
   //////////////////////////////////////////
@@ -137,6 +154,7 @@ namespace ToolKit
   // Conversions and Interpolation
   //////////////////////////////////////////
 
+  /** Linearly interpolate vec1 with vec2 based on the ratio. Formula: (v2-v1)*ratio+v1 */
   TK_API Vec3 Interpolate(const Vec3& vec1, const Vec3& vec2, float ratio);
 
   /** From the given point, calculates radius (r), angle from y axis (zenith), angle in xz plane (azimuth) */
@@ -152,18 +170,17 @@ namespace ToolKit
   TK_API Vec3 Orthogonal(const Vec3& v);
 
   // Comparison
-  //////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////
 
+  /** Tests if all components of given vectors are equal or not. */
   template <typename T>
   bool VecAllEqual(const T& a, const T& b)
   {
     return glm::all(glm::equal<T>(a, b));
   }
 
-  TK_API bool PointInsideBBox(const Vec3& point, const Vec3& max, const Vec3& min);
-
   // Random Generators
-  //////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////
 
   /**
    * Generate random points on a hemisphere with proximity to normal.

--- a/ToolKit/RenderSystem.cpp
+++ b/ToolKit/RenderSystem.cpp
@@ -209,15 +209,6 @@ namespace ToolKit
     }
   }
 
-  bool RenderSystem::ConsumeShadowAtlasInvalidation()
-  {
-    bool temp                = m_shadowAtlasInvalidated;
-    m_shadowAtlasInvalidated = false;
-    return temp;
-  }
-
-  void RenderSystem::InvalidateShadowAtlas() { m_shadowAtlasInvalidated = true; }
-
   bool RenderSystem::ConsumeGPULightCacheInvalidation()
   {
     bool temp                  = m_gpuLightCacheInvalidated;

--- a/ToolKit/RenderSystem.h
+++ b/ToolKit/RenderSystem.h
@@ -66,70 +66,81 @@ namespace ToolKit
      * or render target. Systems that rely on this data updates them selfs.
      * Programmer is responsible to keep this value up to date when application
      * size has changed.
-     * @param width of the Application window.
-     * @param height of the Application window.
      */
     void SetAppWindowSize(uint width, uint height);
 
-    /**
-     * @return Application window size.
-     */
+    /** Application window size. */
     UVec2 GetAppWindowSize();
 
-    /**
-     * Sets default clear color for render targets.
-     * @param clearColor default clear color.
-     */
+    /** Sets default clear color for render targets. */
     void SetClearColor(const Vec4& clearColor);
 
-    uint GetFrameCount();
-    void ResetFrameCount();
-
+    /** Internally used. Enables blending. This should not be used directly. */
     void EnableBlending(bool enable);
 
+    /** Returns elapsed frame count. */
+    uint GetFrameCount();
+
+    /** Set elapsed frame count to zero. */
+    void ResetFrameCount();
+
+    /** Internally used to decrement skip count. */
     void DecrementSkipFrame();
 
+    /** States if this state is skipped. */
     bool IsSkipFrame() const;
 
+    /** Sets number of frames to skip. */
     void SkipSceneFrames(int numFrames);
 
     /**
      * Host application must provide opengl function addresses. This function
      * initialize opengl functions.
-     * @param glGetProcAddress is the adress of opengl function getter.
+     * @param glGetProcAddress is the address of opengl function getter.
      * @param callback is error callback function for opengl.
      */
     void InitGl(void* glGetProcAddres, GlReportCallback callback = nullptr);
 
-    /**
-     * This function should be called by the end of the frame
-     */
+    /** This function should be called by the end of the frame. */
     void EndFrame();
 
-    inline bool IsGammaCorrectionNeeded() { return !m_backbufferFormatIsSRGB; }
+    /** Returns true if back buffer is not srgb. */
+    bool IsGammaCorrectionNeeded() { return !m_backbufferFormatIsSRGB; }
 
+    /** Checks if the backbuffer is srgb and sets m_backbufferFormatIsSRGB. */
     void TestSRGBBackBuffer();
-
-    bool ConsumeShadowAtlasInvalidation();
-    void InvalidateShadowAtlas();
 
     bool ConsumeGPULightCacheInvalidation();
     void InvalidateGPULightCache();
 
    private:
+    /** Implementation for executing render tasks. */
     void ExecuteTaskImp(RenderTask& task);
 
    private:
+    /** High priority render queue. Tasks in this queue always finished. */
     RenderTaskArray m_highQueue;
+
+    /** Low priority render queue. Consume tasks for a given time span and left others for next frame. */
     RenderTaskArray m_lowQueue;
-    Renderer* m_renderer          = nullptr;
-    int m_skipFrames              = 0;
-    bool m_backbufferFormatIsSRGB = true;
-    uint m_frameCount             = 0;
-    bool m_shadowAtlasInvalidated =
-        false; //<! Consumed by ShadowPass to understands if the shadow atlas should be recreated.
-    bool m_gpuLightCacheInvalidated =
-        false; //<! Consumed by Renderer to understands if the light cache should be updated.
+
+    /** Current Renderer. */
+    Renderer* m_renderer            = nullptr;
+
+    /** Holds number of frames to skip. If its greater than zero renderer skip given frames. */
+    int m_skipFrames                = 0;
+
+    /** States if the back buffer is srgb. */
+    bool m_backbufferFormatIsSRGB   = true;
+
+    /** Number of elapsed frames since the engine start. */
+    uint m_frameCount               = 0;
+
+    /** Consumed by ShadowPass to understands if the shadow atlas should be recreated. */
+    bool m_shadowAtlasInvalidated   = false;
+
+    /** Consumed by Renderer to understands if the light cache should be updated. */
+    bool m_gpuLightCacheInvalidated = false;
   };
 
 } // namespace ToolKit

--- a/ToolKit/Scene.cpp
+++ b/ToolKit/Scene.cpp
@@ -241,7 +241,7 @@ namespace ToolKit
 
     pickFn(extraList);
 
-    m_bvh->PickObject(frustum, pickedObjects, ignoreList, extraList, pickPartiallyInside);
+    m_bvh->PickObject(frustum, pickedObjects, ignoreList, pickPartiallyInside);
   }
 
   EntityPtr Scene::GetEntity(ULongID id) const
@@ -478,12 +478,6 @@ namespace ToolKit
   void Scene::RebuildBVH() { m_bvh->ReBuild(); }
 
   const BoundingBox& Scene::GetSceneBoundary() { return m_bvh->GetBVHBoundary(); }
-
-  BoundingBox Scene::GetFrustumBVHBoundary(const CameraPtr& camera) const
-  {
-    const Frustum frustum = ExtractFrustum(camera->GetProjectViewMatrix(), false);
-    return m_bvh->GetFrustumBoundary(frustum);
-  }
 
   void Scene::CopyTo(Resource* other)
   {

--- a/ToolKit/Scene.cpp
+++ b/ToolKit/Scene.cpp
@@ -299,7 +299,9 @@ namespace ToolKit
     {
       if (m_entities[i]->GetIdVal() == id)
       {
-        removed = m_entities[i];
+        removed                    = m_entities[i];
+        removed->m_markedForDelete = true;
+
         UpdateEntityCaches(removed, false);
         m_entities.erase(m_entities.begin() + i);
         m_bvh->RemoveEntity(removed);

--- a/ToolKit/Scene.h
+++ b/ToolKit/Scene.h
@@ -143,8 +143,6 @@ namespace ToolKit
                             const EntityPtrArray& extraList = {},
                             bool pickPartiallyInside        = true);
 
-    // Entity operations.
-
     /**
      * Gets the entity with the given ID from the scene.
      * @param id The ID of the entity to get.

--- a/ToolKit/Scene.h
+++ b/ToolKit/Scene.h
@@ -22,36 +22,27 @@ namespace ToolKit
   /**
    * The Scene class represents a collection of entities in a 3D environment. It
    * provides functionality for loading and saving scenes, updating and querying
-   * entities, and serializing/deserializing to/from XML.
+   * entities, and serializing / deserializing to / from XML.
    */
   class TK_API Scene : public Resource
   {
    public:
     TKDeclareClass(Scene, Resource);
 
-    /**
-     * A helper struct that holds the result of a ray-picking operation in the
-     * scene.
-     */
+    /** A helper struct that holds the result of a ray-picking operation in the scene. */
     struct PickData
     {
-      /**
-       * The position in world space where the ray intersects with the object.
-       */
+      /** The position in world space where the ray intersects with the object. */
       Vec3 pickPos;
 
-      /**
-       * A pointer to the Entity object that was picked.
-       */
+      /** A pointer to the Entity object that was picked. */
       EntityPtr entity = nullptr;
     };
 
     typedef std::vector<PickData> PickDataArray;
 
    public:
-    /**
-     * The constructor for the Scene class.
-     */
+    /** The constructor for the Scene class. */
     Scene();
 
     /**
@@ -61,14 +52,10 @@ namespace ToolKit
      */
     explicit Scene(const String& file);
 
-    /**
-     * The destructor for the Scene class.
-     */
+    /** The destructor for the Scene class. */
     virtual ~Scene();
 
-    /**
-     * Loads the scene from its file.
-     */
+    /** Loads the scene from its file. */
     void Load() override;
 
     /**
@@ -87,22 +74,17 @@ namespace ToolKit
      */
     void Init(bool flushClientSideArray = false) override;
 
-    /**
-     * Uninitializes the scene.
-     */
+    /** Uninitializes the scene. */
     void UnInit() override;
 
     /**
      * Updates the scene by the specified amount of time.
-     *
      * @param deltaTime The time elapsed since the last update.
      */
     virtual void Update(float deltaTime);
 
     /**
-     * Merges the entities from another scene into this scene and clears the
-     * other scene.
-     *
+     * Merges the entities from another scene into this scene and clears the other scene.
      * @param other A pointer to the other scene to merge.
      */
     virtual void Merge(ScenePtr other);
@@ -183,8 +165,7 @@ namespace ToolKit
     SkyBasePtr& GetSky();
 
     /**
-     * Returns an array of pointers to all environment volume components in the
-     * scene.
+     * Returns an array of pointers to all environment volume components in the scene.
      * @returns The array of pointers to environment volume components.
      */
     EnvironmentComponentPtrArray& GetEnvironmentVolumes() const;
@@ -243,9 +224,7 @@ namespace ToolKit
      */
     virtual void RemoveEntity(const EntityPtrArray& entities);
 
-    /**
-     * Removes all entities from the scene.
-     */
+    /** Removes all entities from the scene. */
     virtual void RemoveAllEntities();
 
     /**
@@ -260,22 +239,14 @@ namespace ToolKit
      */
     virtual void SavePrefab(EntityPtr entity);
 
-    /**
-     * Removes all entities from the scene.
-     */
+    /** Removes all entities from the scene. */
     virtual void ClearEntities();
 
-    /**
-     * Rebuilds the BVH
-     */
+    /** Rebuilds the BVH. */
     void RebuildBVH();
 
-    const BoundingBox& GetSceneBoundary(); //!< Returns scene boundary from the BVH.
-
-    /**
-     * Returns the bounding box that containing the BVH nodes that the camera frustum intersects.
-     */
-    BoundingBox GetFrustumBVHBoundary(const CameraPtr& camera) const;
+    /** Returns scene boundary from the BVH. */
+    const BoundingBox& GetSceneBoundary();
 
    protected:
     /**
@@ -292,9 +263,7 @@ namespace ToolKit
      */
     XmlNode* DeSerializeImp(const SerializationFileInfo& info, XmlNode* parent) override;
 
-    /**
-     * Deserialize files with version v0.4.5
-     */
+    /** Deserialize files with version v0.4.5 */
     void DeSerializeImpV045(const SerializationFileInfo& info, XmlNode* parent);
 
     /**

--- a/ToolKit/ShadowPass.cpp
+++ b/ToolKit/ShadowPass.cpp
@@ -387,12 +387,16 @@ namespace ToolKit
     CPU_FUNC_RANGE();
 
     // Check if the shadow atlas needs to be updated
-    bool needChange = false;
-
-    needChange      = GetRenderSystem()->ConsumeShadowAtlasInvalidation();
+    bool needChange                      = false;
+    EngineSettings::GraphicSettings& gfx = GetEngineSettings().Graphics;
+    if (m_activeCascadeCount != gfx.cascadeCount)
+    {
+      m_activeCascadeCount = gfx.cascadeCount;
+      needChange           = true;
+    }
 
     // After this loop m_previousShadowCasters is set with lights with shadows
-    int nextId      = 0;
+    int nextId = 0;
     for (int i = 0; i < m_lights.size(); ++i)
     {
       Light* light = m_lights[i].get();
@@ -419,7 +423,7 @@ namespace ToolKit
       nextId++;
     }
 
-    if (needChange)
+    if (needChange && !m_lights.empty())
     {
       m_previousShadowCasters.resize(nextId);
 

--- a/ToolKit/ShadowPass.h
+++ b/ToolKit/ShadowPass.h
@@ -19,14 +19,12 @@ namespace ToolKit
     CameraPtr viewCamera = nullptr;
   };
 
-  /**
-   * Create shadow map buffers for all given lights.
-   */
+  /** Create shadow map buffers for all given lights. */
   class TK_API ShadowPass : public Pass
   {
    public:
     ShadowPass();
-    explicit ShadowPass(const ShadowPassParams& params);
+    ShadowPass(const ShadowPassParams& params);
     ~ShadowPass();
 
     void Render() override;
@@ -45,9 +43,7 @@ namespace ToolKit
      */
     int PlaceShadowMapsToShadowAtlas(const LightPtrArray& lights);
 
-    /**
-     * Creates a shadow atlas for m_params.Lights
-     */
+    /** Creates a shadow atlas for m_params.Lights */
     void InitShadowAtlas();
 
    public:
@@ -62,6 +58,7 @@ namespace ToolKit
     FramebufferPtr m_shadowFramebuffer = nullptr;
     RenderTargetPtr m_shadowAtlas      = nullptr;
     int m_layerCount                   = 0; // Number of textures in array texture (shadow atlas)
+    int m_activeCascadeCount           = 0;
     IDArray m_previousShadowCasters;
 
     Quaternion m_cubeMapRotations[6];

--- a/ToolKit/Util.cpp
+++ b/ToolKit/Util.cpp
@@ -719,6 +719,7 @@ namespace ToolKit
     Vec3 z = plane.normal;
     Vec3 x = z + Vec3(1.0f);
     Vec3 y = glm::cross(z, x);
+
     x      = glm::normalize(glm::cross(y, z));
     y      = glm::normalize(glm::cross(z, x));
 
@@ -728,11 +729,17 @@ namespace ToolKit
     float hSize = size * 0.5f;
     Vec3Array corners {o + x * hSize + y * hSize,
                        o - x * hSize + y * hSize,
+                       o - x * hSize + y * hSize,
                        o - x * hSize - y * hSize,
-                       o + x * hSize - y * hSize};
+                       o - x * hSize - y * hSize,
+                       o + x * hSize - y * hSize,
+                       o + x * hSize - y * hSize,
+                       o + x * hSize + y * hSize,
+                       o,
+                       o + z};
 
     LineBatchPtr obj = MakeNewPtr<LineBatch>();
-    obj->Generate(corners, X_AXIS, DrawType::LineLoop, 5.0f);
+    obj->Generate(corners, X_AXIS, DrawType::Line, 5.0f);
 
     return obj;
   }

--- a/ToolKit/Util.h
+++ b/ToolKit/Util.h
@@ -290,6 +290,14 @@ namespace ToolKit
     vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
   }
 
+  template <typename T>
+  void Swap(T& data1, T& data2)
+  {
+    T data = data1;
+    data1   = data2;
+    data2   = data;
+  }
+
   //  Time.
   ///////////////////////////////////////////////////////
   TK_API float MillisecToSec(float ms);


### PR DESCRIPTION
Parented objects was remaining in bvh so they were being added to render again. When picked the gohst entities they were causing crash because, pick was trying to find them in scene.

Also refactored plane related codes. Now frustum and any function interact with plane assumes the plane formula as: ax+by+cz+(-d)=0

previously it was a mix of "= d" and "= 0"