### PR TITLE
Stable shadow map fit optimization

### DIFF
--- a/ToolKit/Light.cpp
+++ b/ToolKit/Light.cpp
@@ -422,9 +422,9 @@ namespace ToolKit
   {
     m_shadowCamera->SetLens(glm::radians(GetOuterAngleVal()), 1.0f, 0.01f, AffectDistance());
 
-    Light::UpdateShadowCamera();
-
     UpdateShadowCameraTransform();
+
+    Light::UpdateShadowCamera();
 
     // Calculate frustum.
     m_frustumCache           = ExtractFrustum(m_shadowMapCameraProjectionViewMatrix, false);

--- a/ToolKit/Light.cpp
+++ b/ToolKit/Light.cpp
@@ -179,6 +179,8 @@ namespace ToolKit
       cam->InvalidateSpatialCaches();
       m_cascadeShadowCameras.push_back(cam);
 
+      m_cascadeCullCameras.push_back(Cast<Camera>(cam->Copy()));
+
       m_shadowAtlasLayers.push_back(-1);
       m_shadowAtlasCoords.push_back(Vec2(-1.0f));
     }
@@ -216,7 +218,13 @@ namespace ToolKit
       cameraView->SetNearClipVal(nearClip);
       cameraView->SetFarClipVal(farClip);
 
-      FitViewFrustumIntoLightFrustum(m_cascadeShadowCameras[i], cameraView, nearClip, farClip);
+      FitViewFrustumIntoLightFrustum(m_cascadeShadowCameras[i],
+                                     cameraView,
+                                     nearClip,
+                                     farClip,
+                                     settings.Graphics.stableShadowMap);
+
+      FitViewFrustumIntoLightFrustum(m_cascadeCullCameras[i], cameraView, nearClip, farClip, false);
 
       nearClip = cascadeDists[i];
       farClip  = cascadeDists[i + 1];
@@ -247,59 +255,11 @@ namespace ToolKit
     return node;
   }
 
-  void DirectionalLight::FitEntitiesBBoxIntoShadowFrustum(CameraPtr lightCamera, const RenderJobArray& jobs)
-  {
-    // Calculate all scene's bounding box
-    BoundingBox totalBBox;
-    for (const RenderJob& job : jobs)
-    {
-      if (!job.ShadowCaster)
-      {
-        continue;
-      }
-
-      totalBBox.UpdateBoundary(job.BoundingBox.max);
-      totalBBox.UpdateBoundary(job.BoundingBox.min);
-    }
-    Vec3 center = totalBBox.GetCenter();
-
-    // Set light transformation
-    lightCamera->m_node->SetTranslation(center);
-    lightCamera->m_node->SetOrientation(m_node->GetOrientation());
-    Mat4 lightView   = lightCamera->GetViewMatrix();
-
-    // Bounding box of the scene
-    Vec3 min         = totalBBox.min;
-    Vec3 max         = totalBBox.max;
-    Vec4 vertices[8] = {Vec4(min.x, min.y, min.z, 1.0f),
-                        Vec4(min.x, min.y, max.z, 1.0f),
-                        Vec4(min.x, max.y, min.z, 1.0f),
-                        Vec4(max.x, min.y, min.z, 1.0f),
-                        Vec4(min.x, max.y, max.z, 1.0f),
-                        Vec4(max.x, min.y, max.z, 1.0f),
-                        Vec4(max.x, max.y, min.z, 1.0f),
-                        Vec4(max.x, max.y, max.z, 1.0f)};
-
-    // Calculate bounding box in light space
-    BoundingBox shadowBBox;
-    for (int i = 0; i < 8; ++i)
-    {
-      Vec4 vertex = lightView * vertices[i];
-      shadowBBox.UpdateBoundary(vertex);
-    }
-
-    lightCamera->SetLens(shadowBBox.min.x,
-                         shadowBBox.max.x,
-                         shadowBBox.min.y,
-                         shadowBBox.max.y,
-                         shadowBBox.min.z,
-                         shadowBBox.max.z);
-  }
-
   void DirectionalLight::FitViewFrustumIntoLightFrustum(CameraPtr lightCamera,
                                                         CameraPtr viewCamera,
                                                         float near,
-                                                        float far)
+                                                        float far,
+                                                        bool stableFit)
   {
     // View camera has near far distances coming from i'th cascade boundaries.
     // Shadow camera is aligned with light direction, and positioned to the view camera frustum's center.
@@ -320,7 +280,7 @@ namespace ToolKit
 
     // Calculate tight shadow volume, in light's view.
     BoundingBox tightShadowVolume;
-    if (settings.Graphics.stableShadowMap)
+    if (stableFit)
     {
       // Fit a sphere around the view frustum to prevent swimming when rotating the view camera.
       // Sphere fit will prevent size / center changes of the frustum, which will yield the same shadow map

--- a/ToolKit/Light.h
+++ b/ToolKit/Light.h
@@ -97,16 +97,21 @@ namespace ToolKit
     XmlNode* SerializeImp(XmlDocument* doc, XmlNode* parent) const override;
 
    private:
-    // Fits the entities into the shadow map camera frustum. As the scene gets
-    // bigger, the resolution gets lower.
-    void FitEntitiesBBoxIntoShadowFrustum(CameraPtr lightCamera, const RenderJobArray& jobs);
-
-    // Fits view frustum of the camera into shadow map camera frustum. As the
-    // view frustum gets bigger, the resolution gets lower.
-    void FitViewFrustumIntoLightFrustum(CameraPtr lightCamera, CameraPtr viewCamera, float near, float far);
+    /** Adjust the light frustum such that, it covers entire view camera frustum. */
+    void FitViewFrustumIntoLightFrustum(CameraPtr lightCamera,
+                                        CameraPtr viewCamera,
+                                        float near,
+                                        float far,
+                                        bool stableFit);
 
    public:
+    /** Cascades are rendered with these cameras, due to stable fit, frustum can be larger than actual coverage. */
     CameraPtrArray m_cascadeShadowCameras;
+
+    /** Scene is culled with these tightly fit cameras to create render jobs for shadow map generation. */
+    CameraPtrArray m_cascadeCullCameras;
+
+    /** Cascade camera projection matrices to fill the light buffer. */
     Mat4Array m_shadowMapCascadeCameraProjectionViewMatrices;
   };
 

--- a/ToolKit/ShadowPass.cpp
+++ b/ToolKit/ShadowPass.cpp
@@ -91,6 +91,8 @@ namespace ToolKit
     // Update shadow maps.
     for (LightPtr& light : m_lights)
     {
+      light->UpdateShadowCamera();
+
       if (light->GetLightType() == Light::LightType::Directional)
       {
         DirectionalLightPtr dLight = Cast<DirectionalLight>(light);

--- a/ToolKit/ShadowPass.h
+++ b/ToolKit/ShadowPass.h
@@ -39,7 +39,7 @@ namespace ToolKit
     void RenderShadowMaps(LightPtr light);
 
     /** Performs a single render that generates a single shadow map of a cascade, or a face of a cube etc...*/
-    void RenderShadowMap(LightPtr light, CameraPtr shadowCamera);
+    void RenderShadowMap(LightPtr light, CameraPtr shadowCamera, CameraPtr cullCamera);
 
     /**
      * Sets layer and coordinates of the shadow maps in shadow atlas.


### PR DESCRIPTION
Culling and Rendering know uses 2 different camera, reason is:
Stable fit covers a larger area, but the visible objects from the lights view are inside the tight frustum, the larger area is required to make the shadow map stable. If I use a single camera to both cull and render, culling covers objects that fall outside of the light's view. So I use 2 camera which eleminates the unnecessary objects. Stable and unstable are now have equal performance.